### PR TITLE
fvt: Add Github Action for functional tests

### DIFF
--- a/.github/workflows/run-fvt.yml
+++ b/.github/workflows/run-fvt.yml
@@ -1,0 +1,53 @@
+name: FVTs
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Minikube
+        run: |
+          wget --no-verbose https://github.com/kubernetes/minikube/releases/download/v1.21.0/minikube-linux-amd64
+          sudo cp minikube-linux-amd64 /usr/local/bin/minikube
+          sudo chmod 755 /usr/local/bin/minikube
+          sudo apt-get install -y conntrack socat
+          minikube start --driver=none --kubernetes-version v1.20.7
+      - name: Check pods
+        run: |
+          sleep 30
+          kubectl get pods -n kube-system
+      - name: Set controller image tag
+        run: echo "IMAGE_TAG=$(date +'%Y%m%dT%H%M%S%Z')" >> $GITHUB_ENV
+      - name: Build Controller image
+        run: |
+          make build.develop
+          ./scripts/build_docker.sh --target runtime --tag ${{ env.IMAGE_TAG }}
+      - name: Update configs
+        # Update the image tag and reduce some CPU request amounts to allow FVTs to run
+        # on reduced resource environments.
+        run: |
+          sed -i 's/newTag:.*$/newTag: '"${{ env.IMAGE_TAG }}"'/' config/manager/kustomization.yaml
+          sed -i '0,/cpu:.*$/s/cpu:.*$/cpu: 100m/' \
+            config/default/config-defaults.yaml \
+            config/runtimes/mlserver-0.x.yaml \
+            config/runtimes/triton-2.x.yaml
+      - name: Install ModelMesh Serving
+        run: |
+          kubectl create ns modelmesh-serving
+          ./scripts/install.sh --namespace modelmesh-serving --fvt
+      - name: Pre-pull runtime images
+        run: |
+          docker pull nvcr.io/nvidia/tritonserver:21.06.1-py3
+          docker pull seldonio/mlserver:0.3.2
+      - name: Check installation
+        run: |
+          docker images
+          kubectl get pods
+          kubectl get servingruntimes
+      - name: Run FVTs
+        run: |
+          make fvt

--- a/fvt/predictor_test.go
+++ b/fvt/predictor_test.go
@@ -55,6 +55,9 @@ type FVTPredictor struct {
 const samplesPath string = "testdata/predictors/"
 const userConfigMapName string = "model-serving-config"
 
+// Used for checking if floats are sufficiently close enough.
+const EPSILON float64 = 0.000001
+
 var xgBoostInputData []float32 = []float32{1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0}
 
 // Array of all the predictors that need to be tested
@@ -925,7 +928,7 @@ var _ = Describe("Predictor", func() {
 			// convert raw_output_contents in bytes to array of 10 float32s
 			output, err := convertRawOutputContentsTo10Floats(inferResponse.GetRawOutputContents()[0])
 			Expect(err).ToNot(HaveOccurred())
-			Expect(output[8]).To(BeEquivalentTo(7.343689441680908)) // the 9th class gets the highest activation for this net/image
+			Expect(math.Abs(float64(output[8]-7.343689441680908)) < EPSILON).To(BeTrue()) // the 9th class gets the highest activation for this net/image
 		})
 
 		It("should fail with an invalid input", func() {
@@ -1015,7 +1018,7 @@ var _ = Describe("Predictor", func() {
 			// convert raw_output_contents in bytes to array of 10 float32s
 			output, err := convertRawOutputContentsTo10Floats(inferResponse.GetRawOutputContents()[0])
 			Expect(err).ToNot(HaveOccurred())
-			Expect(output[8]).To(BeEquivalentTo(7.343689441680908)) // the 9th class gets the highest activation for this net/image
+			Expect(math.Abs(float64(output[8]-7.343689441680908)) < EPSILON).To(BeTrue()) // the 9th class gets the highest activation for this net/image
 		})
 
 		It("should fail with an invalid input", func() {

--- a/fvt/scale_to_zero_test.go
+++ b/fvt/scale_to_zero_test.go
@@ -113,6 +113,7 @@ var _ = Describe("Scaling of runtime deployments to zero", func() {
 			By("Creating a test predictor for one Runtime")
 			// ensure single predictor exists
 			fvtClient.ApplyPredictorExpectSuccess(testPredictorObject)
+			time.Sleep(10 * time.Second)
 			ListAllPredictorsExpectOne()
 			// ensure the runtime is ready and scaled up and others are scaled down
 			expectScaledUp()


### PR DESCRIPTION
#### Motivation

This is an attempt to get FVTs running on a per-PR basis which will be used for gating code changes.

#### Modifications

A workflow is added to run the e2e tests on the Github Actions environment using Minikube. Some FVTs were adjusted to get them working on the new environment. 

#### Result

A new FVT check through Github Actions.

Part of https://github.com/kserve/modelmesh-serving/issues/9