### PR TITLE
Exclude some directories from lint checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,5 +20,6 @@ repos:
     rev: 2.1.2
     hooks:
       - id: prettier
+        exclude: ^(.github/|.tekton/)
         args:
           - --no-bracket-spacing


### PR DESCRIPTION
The .tekton and .github directories do not need linting.