### PR TITLE
Fix script for push latest image

### DIFF
--- a/scripts/deploy/iks/build-image-dind.sh
+++ b/scripts/deploy/iks/build-image-dind.sh
@@ -77,6 +77,7 @@ build_image() {
 push_image() {
   echo "=======================Push image to Docker Hub==============================="
   if [[ "$PUBLISH_TAG" == "latest" ]]; then
+    apt update
     apt install jq -y
     apt install curl -y
     export LAST_PUSHED=$(curl -X GET https://hub.docker.com/v2/repositories/${DOCKERHUB_NAMESPACE}/modelmesh-controller/tags/latest | jq -r '.tag_last_pushed')


### PR DESCRIPTION
Fix script for push latest image issue, unable to install jq

#### Motivation
Fix the issue for push latest image where it is unable to install jq

#### Modifications
Add apt update to download package information from all configured sources before apt install

#### Result
jq is installed, and the latest image is pushed to Docker Hub as needed.
