### PR TITLE
feat: Add preliminary REST inferencing support via proxy container

### DIFF
--- a/config/default/config-defaults.yaml
+++ b/config/default/config-defaults.yaml
@@ -26,6 +26,19 @@ modelMeshResources:
   limits:
     cpu: "3"
     memory: "448Mi"
+restProxy:
+  enabled: true
+  port: 8008
+  image:
+    name: kserve/rest-proxy
+    tag: latest
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "96Mi"
+    limits:
+      cpu: "2"
+      memory: "512Mi"
 storageHelperImage:
   name: kserve/modelmesh-runtime-adapter
   tag: latest

--- a/config/default/config-defaults.yaml
+++ b/config/default/config-defaults.yaml
@@ -37,7 +37,7 @@ restProxy:
       cpu: "50m"
       memory: "96Mi"
     limits:
-      cpu: "2"
+      cpu: "1"
       memory: "512Mi"
 storageHelperImage:
   name: kserve/modelmesh-runtime-adapter

--- a/controllers/config.go
+++ b/controllers/config.go
@@ -62,6 +62,7 @@ type Config struct {
 	// Runtimes config
 	ModelMeshImage         ImageConfig
 	ModelMeshResources     ResourceRequirements
+	RESTProxy              RESTProxyConfig
 	StorageHelperImage     ImageConfig
 	StorageHelperResources ResourceRequirements
 	PodsPerRuntime         uint16
@@ -93,6 +94,13 @@ type TLSConfig struct {
 	SecretName string
 	// Mutual TLS disabled if omitted
 	ClientAuth string
+}
+
+type RESTProxyConfig struct {
+	Enabled   bool
+	Port      uint16
+	Image     ImageConfig
+	Resources ResourceRequirements
 }
 
 func (c *Config) GetEtcdSecretName() string {
@@ -360,6 +368,9 @@ func NewMergedConfigFromString(configYaml string) (*Config, error) {
 	// extra validations on parsed config
 	if err = config.ModelMeshResources.parseAndValidate(); err != nil {
 		return nil, fmt.Errorf("Invalid config for 'ModelMeshResources': %s", err)
+	}
+	if err = config.RESTProxy.Resources.parseAndValidate(); err != nil {
+		return nil, fmt.Errorf("Invalid config for 'RESTProxy.Resources': %s", err)
 	}
 	if err = config.StorageHelperResources.parseAndValidate(); err != nil {
 		return nil, fmt.Errorf("Invalid config for 'StorageHelperResources': %s", err)

--- a/controllers/modelmesh/const.go
+++ b/controllers/modelmesh/const.go
@@ -15,6 +15,7 @@ package modelmesh
 
 const (
 	ModelMeshContainer = "mm"
+	RESTProxyContainer = "rest-proxy"
 
 	GrpcPortEnvVar         = "INTERNAL_GRPC_PORT"
 	ServeGrpcPortEnvVar    = "INTERNAL_SERVING_GRPC_PORT"

--- a/controllers/modelmesh/modelmesh.go
+++ b/controllers/modelmesh/modelmesh.go
@@ -37,6 +37,7 @@ const ModelMeshEtcdPrefix = "mm"
 //Models a deployment
 type Deployment struct {
 	ServiceName        string
+	ServicePort        uint16
 	Name               string
 	Namespace          string
 	Owner              *api.ServingRuntime
@@ -47,6 +48,10 @@ type Deployment struct {
 	PrometheusScheme   string
 	ModelMeshImage     string
 	ModelMeshResources *corev1.ResourceRequirements
+	RESTProxyEnabled   bool
+	RESTProxyImage     string
+	RESTProxyResources *corev1.ResourceRequirements
+	RESTProxyPort      uint16
 	// internal fields used when templating
 	ModelMeshLimitCPU       string
 	ModelMeshRequestsCPU    string
@@ -113,6 +118,7 @@ func (m *Deployment) Apply(ctx context.Context) error {
 				m.addMMEnvVars,
 				m.addModelTypeConstraints,
 				m.configureMMDeploymentForEtcdSecret,
+				m.addRESTProxyToDeployment,
 				m.configureMMDeploymentForTLSSecret,
 			); tErr != nil {
 				return tErr

--- a/controllers/modelmesh/proxy.go
+++ b/controllers/modelmesh/proxy.go
@@ -1,0 +1,57 @@
+// Copyright 2021 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package modelmesh
+
+import (
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	restProxyPortEnvVar     = "REST_PROXY_LISTEN_PORT"
+	restProxyGrpcPortEnvVar = "REST_PROXY_GRPC_PORT"
+	restProxyTlsEnvVar      = "REST_PROXY_USE_TLS"
+)
+
+func (m *Deployment) addRESTProxyToDeployment(deployment *appsv1.Deployment) error {
+
+	if m.RESTProxyEnabled {
+		enableTLS := "false"
+		if m.TLSSecretName != "" {
+			enableTLS = "true"
+		}
+
+		cspec := corev1.Container{
+			Image: m.RESTProxyImage,
+			Name:  RESTProxyContainer,
+			Env: []corev1.EnvVar{
+				{Name: restProxyPortEnvVar, Value: fmt.Sprintf("%d", m.RESTProxyPort)},
+				{Name: restProxyGrpcPortEnvVar, Value: fmt.Sprintf("%d", m.ServicePort)},
+				{Name: restProxyTlsEnvVar, Value: enableTLS},
+			},
+			Ports: []corev1.ContainerPort{
+				{
+					Name:          "http",
+					ContainerPort: int32(m.RESTProxyPort),
+				},
+			},
+			Resources: *m.RESTProxyResources,
+		}
+
+		deployment.Spec.Template.Spec.Containers = append(deployment.Spec.Template.Spec.Containers, cspec)
+	}
+	return nil
+}

--- a/controllers/modelmesh/proxy.go
+++ b/controllers/modelmesh/proxy.go
@@ -14,7 +14,7 @@
 package modelmesh
 
 import (
-	"fmt"
+	"strconv"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -29,18 +29,20 @@ const (
 func (m *Deployment) addRESTProxyToDeployment(deployment *appsv1.Deployment) error {
 
 	if m.RESTProxyEnabled {
-		enableTLS := "false"
-		if m.TLSSecretName != "" {
-			enableTLS = "true"
-		}
-
 		cspec := corev1.Container{
 			Image: m.RESTProxyImage,
 			Name:  RESTProxyContainer,
 			Env: []corev1.EnvVar{
-				{Name: restProxyPortEnvVar, Value: fmt.Sprintf("%d", m.RESTProxyPort)},
-				{Name: restProxyGrpcPortEnvVar, Value: fmt.Sprintf("%d", m.ServicePort)},
-				{Name: restProxyTlsEnvVar, Value: enableTLS},
+				{
+					Name:  restProxyPortEnvVar,
+					Value: strconv.Itoa(int(m.RESTProxyPort)),
+				}, {
+					Name:  restProxyGrpcPortEnvVar,
+					Value: strconv.Itoa(int(m.ServicePort)),
+				}, {
+					Name:  restProxyTlsEnvVar,
+					Value: strconv.FormatBool(m.TLSSecretName != ""),
+				},
 			},
 			Ports: []corev1.ContainerPort{
 				{

--- a/controllers/modelmesh/tls.go
+++ b/controllers/modelmesh/tls.go
@@ -63,7 +63,7 @@ func (m *Deployment) configureMMDeploymentForTLSSecret(deployment *appsv1.Deploy
 	podSpec := &deployment.Spec.Template.Spec
 	for ci := range podSpec.Containers {
 		container := &podSpec.Containers[ci]
-		if container.Name == ModelMeshContainer {
+		if container.Name == ModelMeshContainer || (m.RESTProxyEnabled && container.Name == RESTProxyContainer) {
 			container.Env = append(container.Env, corev1.EnvVar{
 				Name: tlsCertEnvVar, Value: tlsSecretMountPath + "/" + TLSSecretCertKey,
 			})
@@ -98,7 +98,6 @@ func (m *Deployment) configureMMDeploymentForTLSSecret(deployment *appsv1.Deploy
 			}
 			vm.ReadOnly = true
 			vm.MountPath = tlsSecretMountPath
-			break
 		}
 	}
 

--- a/controllers/predictor_controller.go
+++ b/controllers/predictor_controller.go
@@ -437,7 +437,7 @@ func (pr *PredictorReconciler) updatePredictorStatusFromVModel(status *api.Predi
 	status.Available = status.ActiveModelState != "" &&
 		status.ActiveModelState != api.FailedToLoad && !status.WaitingForRuntime()
 	status.GrpcEndpoint = fmt.Sprintf("grpc://%s", pr.MMService.InferenceEndpoint())
-	status.HTTPEndpoint = "" //TODO not yet supported
+	status.HTTPEndpoint = pr.MMService.InferenceRESTEndpoint()
 
 	// This will be reinstated once the loading/loaded counts are added back to the Predictor CRD Status
 	//if counts != [3]int{status.LoadingCopies, status.LoadedCopies, status.FailedCopies} {

--- a/controllers/service_controller.go
+++ b/controllers/service_controller.go
@@ -90,13 +90,16 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		if err != nil {
 			return RequeueResult, err
 		}
-		var metricsPort uint16 = 0
+		var metricsPort, restProxyPort uint16 = 0, 0
 		if cfg.Metrics.Enabled {
 			metricsPort = cfg.Metrics.Port
 		}
+		if cfg.RESTProxy.Enabled {
+			restProxyPort = cfg.RESTProxy.Port
+		}
 		changed = r.ModelMeshService.UpdateConfig(
 			cfg.InferenceServiceName, cfg.InferenceServicePort,
-			cfg.ModelMeshEndpoint, cfg.TLS.SecretName, tlsConfig, cfg.HeadlessService, metricsPort, cfg.RESTProxy.Port)
+			cfg.ModelMeshEndpoint, cfg.TLS.SecretName, tlsConfig, cfg.HeadlessService, metricsPort, restProxyPort)
 	}
 
 	d := &appsv1.Deployment{}

--- a/controllers/service_controller.go
+++ b/controllers/service_controller.go
@@ -96,7 +96,7 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 		changed = r.ModelMeshService.UpdateConfig(
 			cfg.InferenceServiceName, cfg.InferenceServicePort,
-			cfg.ModelMeshEndpoint, cfg.TLS.SecretName, tlsConfig, cfg.HeadlessService, metricsPort)
+			cfg.ModelMeshEndpoint, cfg.TLS.SecretName, tlsConfig, cfg.HeadlessService, metricsPort, cfg.RESTProxy.Port)
 	}
 
 	d := &appsv1.Deployment{}
@@ -213,6 +213,14 @@ func (r *ServiceReconciler) applyService(ctx context.Context, d *appsv1.Deployme
 			Name:       "prometheus",
 			Port:       int32(r.ModelMeshService.MetricsPort),
 			TargetPort: intstr.FromString("prometheus"),
+		})
+	}
+
+	if r.ModelMeshService.RESTPort > 0 {
+		s.Spec.Ports = append(s.Spec.Ports, corev1.ServicePort{
+			Name:       "http",
+			Port:       int32(r.ModelMeshService.RESTPort),
+			TargetPort: intstr.FromString("http"),
 		})
 	}
 

--- a/controllers/servingruntime_controller.go
+++ b/controllers/servingruntime_controller.go
@@ -138,6 +138,7 @@ func (r *ServingRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	config := r.ConfigProvider.GetConfig()
 	mmDeployment := modelmesh.Deployment{
 		ServiceName:        config.InferenceServiceName,
+		ServicePort:        config.InferenceServicePort,
 		Name:               req.Name,
 		Namespace:          req.Namespace,
 		Owner:              rt,
@@ -148,6 +149,10 @@ func (r *ServingRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		PrometheusScheme:   config.Metrics.Scheme,
 		ModelMeshImage:     config.ModelMeshImage.TaggedImage(),
 		ModelMeshResources: config.ModelMeshResources.ToKubernetesType(),
+		RESTProxyEnabled:   config.RESTProxy.Enabled,
+		RESTProxyImage:     config.RESTProxy.Image.TaggedImage(),
+		RESTProxyPort:      config.RESTProxy.Port,
+		RESTProxyResources: config.RESTProxy.Resources.ToKubernetesType(),
 		PullerImage:        config.StorageHelperImage.TaggedImage(),
 		PullerImageCommand: config.StorageHelperImage.Command,
 		PullerResources:    config.StorageHelperResources.ToKubernetesType(),

--- a/controllers/servingruntime_controller_test.go
+++ b/controllers/servingruntime_controller_test.go
@@ -165,3 +165,30 @@ var _ = Describe("Serving runtime with storageHelper disabled", func() {
 		Expect(d).To(SnapshotMatcher())
 	})
 })
+
+var _ = Describe("REST Proxy configuration", func() {
+	var m mf.Manifest
+	var err error
+
+	It("deployment should contain REST Proxy container", func() {
+		By("enable REST Proxy in the config")
+		reconcilerConfig.RESTProxy.Enabled = true
+
+		By("create a sample runtime")
+		m, err = mf.ManifestFrom(mf.Path("../config/runtimes/mlserver-0.x.yaml"))
+		m.Client = mfc.NewClient(k8sClient)
+		Expect(err).ToNot(HaveOccurred())
+		m, err = m.Transform(mf.InjectNamespace(namespace))
+		Expect(err).ToNot(HaveOccurred())
+		err = m.Apply()
+		Expect(err).ToNot(HaveOccurred())
+
+		By("check the generated Deployment")
+		srName := m.Resources()[0].GetName()
+		d := waitForAndGetRuntimeDeployment(srName)
+
+		// discard objectmeta before snapshot compare to remove generated values
+		d.ObjectMeta = metav1.ObjectMeta{}
+		Expect(d).To(SnapshotMatcher())
+	})
+})

--- a/controllers/testdata/servingruntime_controller.golden
+++ b/controllers/testdata/servingruntime_controller.golden
@@ -228,6 +228,249 @@ spec:
         - mountPath: /storage-config
           name: storage-config
           readOnly: true
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 90
+      volumes:
+      - emptyDir:
+          sizeLimit: 1536Mi
+        name: models-dir
+      - name: storage-config
+        secret:
+          defaultMode: 420
+          secretName: storage-config
+      - configMap:
+          defaultMode: 420
+          name: tc-config
+        name: tc-config
+      - name: etcd-config
+        secret:
+          defaultMode: 420
+          secretName: secret
+status: {}
+'''
+"REST Proxy configuration deployment should contain REST Proxy container" = '''
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 2
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      component: model-mesh
+      modelmesh-service: modelmesh-serving
+      name: modelmesh-serving-mlserver-0.x
+  strategy:
+    rollingUpdate:
+      maxSurge: 75%
+      maxUnavailable: 15%
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: modelmesh-controller
+        app.kubernetes.io/managed-by: modelmesh-controller
+        app.kubernetes.io/name: modelmesh-controller
+        component: model-mesh
+        modelmesh-service: modelmesh-serving
+        name: modelmesh-serving-mlserver-0.x
+        network-policy: allow-egress
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+      containers:
+      - env:
+        - name: MM_SERVICE_NAME
+          value: modelmesh-serving
+        - name: MM_SVC_GRPC_PORT
+          value: "1234"
+        - name: WKUBE_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: WKUBE_POD_IPADDR
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: MM_LOCATION
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.hostIP
+        - name: KV_STORE
+          value: etcd:/opt/kserve/mmesh/etcd/etcd_connection
+        - name: MM_METRICS
+          value: disabled
+        - name: SHUTDOWN_TIMEOUT_MS
+          value: "90000"
+        - name: INTERNAL_SERVING_GRPC_PORT
+          value: "8001"
+        - name: INTERNAL_GRPC_PORT
+          value: "8085"
+        - name: MM_SVC_GRPC_MAX_MSG_SIZE
+          value: "16777216"
+        - name: MM_KVSTORE_PREFIX
+          value: mm
+        - name: MM_DEFAULT_VMODEL_OWNER
+          value: ksp
+        - name: MM_LABELS
+          value: mt:lightgbm,mt:lightgbm:3,mt:sklearn,mt:sklearn:0,mt:xgboost,mt:xgboost:1,rt:mlserver-0.x
+        - name: MM_TYPE_CONSTRAINTS_PATH
+          value: /etc/watson/mmesh/config/type_constraints
+        - name: MM_DATAPLANE_CONFIG_PATH
+          value: /etc/watson/mmesh/config/dataplane_api_config
+        image: image:tag
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /opt/kserve/mmesh/stop.sh
+              - wait
+        livenessProbe:
+          failureThreshold: 2
+          httpGet:
+            path: /live
+            port: 8089
+            scheme: HTTP
+          initialDelaySeconds: 90
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 5
+        name: mm
+        ports:
+        - containerPort: 1234
+          name: grpc
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /ready
+            port: 8089
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: "3"
+            memory: 448Mi
+          requests:
+            cpu: 300m
+            memory: 448Mi
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/watson/mmesh/config
+          name: tc-config
+        - mountPath: /opt/kserve/mmesh/etcd
+          name: etcd-config
+          readOnly: true
+      - env:
+        - name: MLSERVER_MODELS_DIR
+          value: /models/_mlserver_models/
+        - name: MLSERVER_GRPC_PORT
+          value: "8001"
+        - name: MLSERVER_HTTP_PORT
+          value: "8002"
+        - name: MLSERVER_LOAD_MODELS_AT_STARTUP
+          value: "false"
+        - name: MLSERVER_MODEL_NAME
+          value: dummy-model-fixme
+        - name: MLSERVER_HOST
+          value: 127.0.0.1
+        image: mlserver-0:replace
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            httpGet:
+              path: /prestop
+              port: 8090
+              scheme: HTTP
+        name: mlserver
+        resources:
+          limits:
+            cpu: "5"
+            memory: 1Gi
+          requests:
+            cpu: 500m
+            memory: 1Gi
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /models
+          name: models-dir
+      - command:
+        - /opt/app/mlserver-adapter
+        env:
+        - name: ADAPTER_PORT
+          value: "8085"
+        - name: RUNTIME_PORT
+          value: "8001"
+        - name: CONTAINER_MEM_REQ_BYTES
+          valueFrom:
+            resourceFieldRef:
+              containerName: mlserver
+              divisor: "0"
+              resource: requests.memory
+        - name: MEM_BUFFER_BYTES
+          value: "134217728"
+        - name: LOADTIME_TIMEOUT
+          value: "90000"
+        - name: USE_EMBEDDED_PULLER
+          value: "true"
+        image: image:tag
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            httpGet:
+              path: /prestop
+              port: 8090
+              scheme: HTTP
+        name: mlserver-adapter
+        resources:
+          limits:
+            cpu: "2"
+            memory: 512Mi
+          requests:
+            cpu: 50m
+            memory: 96Mi
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /models
+          name: models-dir
+        - mountPath: /storage-config
+          name: storage-config
+          readOnly: true
       - env:
         - name: REST_PROXY_LISTEN_PORT
           value: "8008"
@@ -244,7 +487,7 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: "2"
+            cpu: "1"
             memory: 512Mi
           requests:
             cpu: 50m
@@ -494,29 +737,6 @@ spec:
         - mountPath: /storage-config
           name: storage-config
           readOnly: true
-      - env:
-        - name: REST_PROXY_LISTEN_PORT
-          value: "8008"
-        - name: REST_PROXY_GRPC_PORT
-          value: "1234"
-        - name: REST_PROXY_USE_TLS
-          value: "false"
-        image: kserve/rest-proxy:latest
-        imagePullPolicy: Always
-        name: rest-proxy
-        ports:
-        - containerPort: 8008
-          name: http
-          protocol: TCP
-        resources:
-          limits:
-            cpu: "2"
-            memory: 512Mi
-          requests:
-            cpu: 50m
-            memory: 96Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -770,29 +990,6 @@ spec:
         - mountPath: /storage-config
           name: storage-config
           readOnly: true
-      - env:
-        - name: REST_PROXY_LISTEN_PORT
-          value: "8008"
-        - name: REST_PROXY_GRPC_PORT
-          value: "1234"
-        - name: REST_PROXY_USE_TLS
-          value: "false"
-        image: kserve/rest-proxy:latest
-        imagePullPolicy: Always
-        name: rest-proxy
-        ports:
-        - containerPort: 8008
-          name: http
-          protocol: TCP
-        resources:
-          limits:
-            cpu: "2"
-            memory: 512Mi
-          requests:
-            cpu: 50m
-            memory: 96Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -985,29 +1182,6 @@ spec:
         volumeMounts:
         - mountPath: /models
           name: models-dir
-      - env:
-        - name: REST_PROXY_LISTEN_PORT
-          value: "8008"
-        - name: REST_PROXY_GRPC_PORT
-          value: "1234"
-        - name: REST_PROXY_USE_TLS
-          value: "false"
-        image: kserve/rest-proxy:latest
-        imagePullPolicy: Always
-        name: rest-proxy
-        ports:
-        - containerPort: 8008
-          name: http
-          protocol: TCP
-        resources:
-          limits:
-            cpu: "2"
-            memory: 512Mi
-          requests:
-            cpu: 50m
-            memory: 96Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/controllers/testdata/servingruntime_controller.golden
+++ b/controllers/testdata/servingruntime_controller.golden
@@ -228,6 +228,29 @@ spec:
         - mountPath: /storage-config
           name: storage-config
           readOnly: true
+      - env:
+        - name: REST_PROXY_LISTEN_PORT
+          value: "8008"
+        - name: REST_PROXY_GRPC_PORT
+          value: "1234"
+        - name: REST_PROXY_USE_TLS
+          value: "false"
+        image: kserve/rest-proxy:latest
+        imagePullPolicy: Always
+        name: rest-proxy
+        ports:
+        - containerPort: 8008
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            cpu: "2"
+            memory: 512Mi
+          requests:
+            cpu: 50m
+            memory: 96Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -471,6 +494,29 @@ spec:
         - mountPath: /storage-config
           name: storage-config
           readOnly: true
+      - env:
+        - name: REST_PROXY_LISTEN_PORT
+          value: "8008"
+        - name: REST_PROXY_GRPC_PORT
+          value: "1234"
+        - name: REST_PROXY_USE_TLS
+          value: "false"
+        image: kserve/rest-proxy:latest
+        imagePullPolicy: Always
+        name: rest-proxy
+        ports:
+        - containerPort: 8008
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            cpu: "2"
+            memory: 512Mi
+          requests:
+            cpu: 50m
+            memory: 96Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -724,6 +770,29 @@ spec:
         - mountPath: /storage-config
           name: storage-config
           readOnly: true
+      - env:
+        - name: REST_PROXY_LISTEN_PORT
+          value: "8008"
+        - name: REST_PROXY_GRPC_PORT
+          value: "1234"
+        - name: REST_PROXY_USE_TLS
+          value: "false"
+        image: kserve/rest-proxy:latest
+        imagePullPolicy: Always
+        name: rest-proxy
+        ports:
+        - containerPort: 8008
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            cpu: "2"
+            memory: 512Mi
+          requests:
+            cpu: 50m
+            memory: 96Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -916,6 +985,29 @@ spec:
         volumeMounts:
         - mountPath: /models
           name: models-dir
+      - env:
+        - name: REST_PROXY_LISTEN_PORT
+          value: "8008"
+        - name: REST_PROXY_GRPC_PORT
+          value: "1234"
+        - name: REST_PROXY_USE_TLS
+          value: "false"
+        image: kserve/rest-proxy:latest
+        imagePullPolicy: Always
+        name: rest-proxy
+        ports:
+        - containerPort: 8008
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            cpu: "2"
+            memory: 512Mi
+          requests:
+            cpu: 50m
+            memory: 96Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/controllers/testdata/test-config-defaults.yaml
+++ b/controllers/testdata/test-config-defaults.yaml
@@ -33,3 +33,16 @@ metrics:
 scaleToZero:
   enabled: false
   gracePeriodSeconds: 60
+restProxy:
+  enabled: false
+  port: 8008
+  image:
+    name: kserve/rest-proxy
+    tag: latest
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "96Mi"
+    limits:
+      cpu: "1"
+      memory: "512Mi"

--- a/main.go
+++ b/main.go
@@ -153,7 +153,8 @@ func main() {
 	conf := cp.GetConfig()
 
 	setupLog.Info("Using adapter", "image", conf.StorageHelperImage.TaggedImage())
-	setupLog.Info("Using model-mesh", "image", conf.ModelMeshImage.TaggedImage())
+	setupLog.Info("Using modelmesh", "image", conf.ModelMeshImage.TaggedImage())
+	setupLog.Info("Using modelmesh REST proxy", "image", conf.RESTProxy.Image.TaggedImage())
 	setupLog.Info("Using inference service", "name", conf.InferenceServiceName, "port", conf.InferenceServicePort)
 
 	// mmesh service kubedns or hostname

--- a/main.go
+++ b/main.go
@@ -154,7 +154,10 @@ func main() {
 
 	setupLog.Info("Using adapter", "image", conf.StorageHelperImage.TaggedImage())
 	setupLog.Info("Using modelmesh", "image", conf.ModelMeshImage.TaggedImage())
-	setupLog.Info("Using modelmesh REST proxy", "image", conf.RESTProxy.Image.TaggedImage())
+
+	if conf.RESTProxy.Enabled {
+		setupLog.Info("Using modelmesh REST proxy", "image", conf.RESTProxy.Image.TaggedImage())
+	}
 	setupLog.Info("Using inference service", "name", conf.InferenceServiceName, "port", conf.InferenceServicePort)
 
 	// mmesh service kubedns or hostname

--- a/pkg/mmesh/modelmesh_service.go
+++ b/pkg/mmesh/modelmesh_service.go
@@ -40,6 +40,7 @@ type MMService struct {
 	mmClient *mmClient
 
 	MetricsPort uint16
+	RESTPort    uint16
 }
 
 func NewMMService() *MMService {
@@ -47,7 +48,7 @@ func NewMMService() *MMService {
 }
 
 func (mms *MMService) UpdateConfig(name string, port uint16,
-	endpoint, tlsSecretName string, tlsConfig *tls.Config, headless bool, metricsPort uint16) bool {
+	endpoint, tlsSecretName string, tlsConfig *tls.Config, headless bool, metricsPort uint16, restPort uint16) bool {
 	changed := false
 	if name != mms.Name {
 		mms.Name = name
@@ -77,6 +78,10 @@ func (mms *MMService) UpdateConfig(name string, port uint16,
 		mms.MetricsPort = metricsPort
 		changed = true
 	}
+	if restPort != mms.RESTPort {
+		mms.RESTPort = restPort
+		changed = true
+	}
 	return changed
 }
 
@@ -87,6 +92,14 @@ type mmClient struct {
 
 func (mms *MMService) InferenceEndpoint() string {
 	return fmt.Sprintf("%s:%d", mms.Name, mms.Port)
+}
+
+func (mms *MMService) InferenceRESTEndpoint() string {
+	scheme := "http"
+	if mms.TLSConfig != nil {
+		scheme = "https"
+	}
+	return fmt.Sprintf("%s://%s:%d", scheme, mms.Name, mms.RESTPort)
 }
 
 func (mms *MMService) MMClient() mmeshapi.ModelMeshClient {

--- a/pkg/mmesh/modelmesh_service.go
+++ b/pkg/mmesh/modelmesh_service.go
@@ -95,6 +95,9 @@ func (mms *MMService) InferenceEndpoint() string {
 }
 
 func (mms *MMService) InferenceRESTEndpoint() string {
+	if mms.RESTPort <= 0 {
+		return ""
+	}
 	scheme := "http"
 	if mms.TLSConfig != nil {
 		scheme = "https"


### PR DESCRIPTION
This PR adds preliminary REST support for ModelMesh inferencing. Config options are now available for enabling a REST Proxy container to be deployed as part of a ServingRuntime deployment. 

In the `proxy` directory are the files necessary to build this proxy container. 

Related: #6 