### PR TITLE
Adjust FVT GH-Actions workflow

### DIFF
--- a/.github/workflows/run-fvt.yml
+++ b/.github/workflows/run-fvt.yml
@@ -3,11 +3,13 @@ name: FVTs
 on:
   pull_request:
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
-      - '**.md'
-      - '.github/**'
-      - '.tekton/**'
+    paths:
+      - '**'
+      - '!.github/**'
+      - '!.tekton/**'
+      - '!docs/**'
+      - '!**.md'
+      - '.github/workflows/run-fvt.yml'
 
 jobs:
   test:
@@ -27,19 +29,22 @@ jobs:
           kubectl get pods -n kube-system
       - name: Set controller image tag
         run: echo "IMAGE_TAG=$(date +'%Y%m%dT%H%M%S%Z')" >> $GITHUB_ENV
-      - name: Build Controller image
-        run: |
-          make build.develop
-          ./scripts/build_docker.sh --target runtime --tag ${{ env.IMAGE_TAG }}
       - name: Update configs
         # Update the image tag and reduce some CPU request amounts to allow FVTs to run
-        # on reduced resource environments.
+        # on reduced resource environments. Also the RollingUpdate strategy for Runtime deployments
+        # is adjusted for these environments.
         run: |
           sed -i 's/newTag:.*$/newTag: '"${{ env.IMAGE_TAG }}"'/' config/manager/kustomization.yaml
           sed -i '0,/cpu:.*$/s/cpu:.*$/cpu: 100m/' \
             config/default/config-defaults.yaml \
             config/runtimes/mlserver-0.x.yaml \
             config/runtimes/triton-2.x.yaml
+          sed -i 's/maxSurge:.*$/maxSurge: 0/' config/internal/base/deployment.yaml.tmpl
+          sed -i 's/maxUnavailable:.*$/maxUnavailable: 100%/' config/internal/base/deployment.yaml.tmpl
+      - name: Build Controller image
+        run: |
+          make build.develop
+          ./scripts/build_docker.sh --target runtime --tag ${{ env.IMAGE_TAG }}
       - name: Install ModelMesh Serving
         run: |
           kubectl create ns modelmesh-serving

--- a/fvt/fvtclient_test.go
+++ b/fvt/fvtclient_test.go
@@ -48,7 +48,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-var defaultTimeout = int64(120)
+var defaultTimeout = int64(180)
 
 const predictorTimeout = time.Second * 120
 const timeForStatusToStabilize = time.Second * 5


### PR DESCRIPTION
#### Motivation
Decrease the flakiness of FVT runs that occur when certain tests are run back to back.

#### Modifications
The rollingUpdate strategy is adjusted in a preprocessing step of the FVT Github Actions workflow to allow better stability in low resource environments. The defaultTimeout was increased to account for the the changes in strategy. Ran into some intermittent failures due to timeouts when the deployment doesn't become ready in time.

#### Result
Less flakiness in FVT runs.