### PR TITLE
[POC] storage phase 1 for modelmesh reconciler

### DIFF
--- a/apis/kfserving/v1alpha1/trainedmodel_registry_test.go
+++ b/apis/kfserving/v1alpha1/trainedmodel_registry_test.go
@@ -1,0 +1,53 @@
+// Copyright 2021 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package v1alpha1
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestProcessTrainedModelStorage(t *testing.T) {
+	storageKey := "localMinIO"
+	storagePath := "sklearn/mnist-svm.joblib"
+	storageBucket := "modelmesh-example-models"
+
+	var secretKey string
+	var bucket string
+	var modelPath string
+	nname := types.NamespacedName{Name: "tm-test-model", Namespace: "modelmesh-serving"}
+	trainedModel := &TrainedModel{
+		Spec: TrainedModelSpec{
+			Model: ModelSpec{
+				Storage: &StorageSpec{
+					StorageKey: &storageKey,
+					Path:       &storagePath,
+					Parameters: &map[string]string{
+						"bucket": storageBucket,
+					},
+				},
+			},
+		},
+	}
+	err := ProcessTrainedModelStorage(&secretKey, &bucket, &modelPath, trainedModel, nname)
+	if err != nil {
+		fmt.Println(err)
+	}
+	expected := [3]string{secretKey, bucket, modelPath}
+	result := [3]string{storageKey, storageBucket, storagePath}
+	assert.Equal(t, result, expected)
+}

--- a/apis/kfserving/v1alpha1/trainedmodel_types.go
+++ b/apis/kfserving/v1alpha1/trainedmodel_types.go
@@ -88,12 +88,29 @@ type TrainedModelList struct {
 // ModelSpec describes a TrainedModel
 type ModelSpec struct {
 	// Storage URI for the model repository
+	// +optional
 	StorageURI string `json:"storageUri"`
 	// Machine Learning <framework name>
 	// The values could be: "tensorflow","pytorch","sklearn","onnx","xgboost", "myawesomeinternalframework" etc.
 	Framework string `json:"framework"`
 	// Maximum memory this model will consume, this field is used to decide if a model server has enough memory to load this model.
 	Memory resource.Quantity `json:"memory"`
+	// Storage Spec for model location
+	// +optional
+	Storage *StorageSpec `json:"storage,omitempty"`
+}
+
+type StorageSpec struct {
+	// The path to the model object in the storage. It cannot co-exist
+	// with the storageURI.
+	// +optional
+	Path *string `json:"path,omitempty"`
+	// Parameters to override the default storage credentials and config.
+	// +optional
+	Parameters *map[string]string `json:"parameters,omitempty"`
+	// The Storage Key in the secret for this model.
+	// +optional
+	StorageKey *string `json:"key,omitempty"`
 }
 
 func init() {

--- a/config/crd/kfserving-crd/trainedmodel.yaml
+++ b/config/crd/kfserving-crd/trainedmodel.yaml
@@ -1,0 +1,124 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.1-0.20200528125929-5c0c6ae3b64b
+  creationTimestamp: null
+  name: trainedmodels.serving.kubeflow.org
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.url
+    name: URL
+    type: string
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  group: serving.kubeflow.org
+  names:
+    kind: TrainedModel
+    listKind: TrainedModelList
+    plural: trainedmodels
+    shortNames:
+    - tm
+    singular: trainedmodel
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            inferenceService:
+              type: string
+            model:
+              properties:
+                framework:
+                  type: string
+                memory:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                storageUri:
+                  type: string
+                storage:
+                  properties:
+                    path:
+                      type: string
+                    key:
+                      type: string
+                    parameters:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+              required:
+              - framework
+              - memory
+              type: object
+          required:
+          - inferenceService
+          - model
+          type: object
+        status:
+          properties:
+            address:
+              properties:
+                url:
+                  type: string
+              type: object
+            annotations:
+              additionalProperties:
+                type: string
+              type: object
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  severity:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            observedGeneration:
+              format: int64
+              type: integer
+            url:
+              type: string
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
#### Motivation
Add new Storage Spec for phase 1 in modelmesh serving reconciler. The initial version added new storage spec to trainedModel CRDs.

For Storage Spec details, please refer to the design doc: https://docs.google.com/document/d/1rYNh93XNMRp8YaR56m-_zK3bqpZhhGKgpVbLPPsi-Ow/edit#

Additional storage/parameter supports will come in phase 2.

#### Modifications

#### Result
