### PR TITLE
fix: Prevent chmod errors in log after unexpected triton restart

### DIFF
--- a/config/runtimes/triton-2.x.yaml
+++ b/config/runtimes/triton-2.x.yaml
@@ -40,7 +40,7 @@ spec:
       args:
         - -c
         - 'mkdir -p /models/_triton_models;
-          chmod -R 777 /models/_triton_models;
+          chmod 777 /models/_triton_models;
           exec tritonserver
           "--model-repository=/models/_triton_models"
           "--model-control-mode=explicit"

--- a/controllers/testdata/servingruntime_controller.golden
+++ b/controllers/testdata/servingruntime_controller.golden
@@ -631,7 +631,7 @@ spec:
           readOnly: true
       - args:
         - -c
-        - 'mkdir -p /models/_triton_models; chmod -R 777 /models/_triton_models; exec
+        - 'mkdir -p /models/_triton_models; chmod 777 /models/_triton_models; exec
           tritonserver "--model-repository=/models/_triton_models" "--model-control-mode=explicit"
           "--strict-model-config=false" "--strict-readiness=false" "--allow-http=true"
           "--allow-sagemaker=false" '


### PR DESCRIPTION
#### Motivation

Errors were observed by @tedhtchang in this situation:
```
chmod: changing permissions of '/models/_triton_models/simple-string-1180__ksp-a53a19561f/config.pbtxt': Operation not permitted
chmod: changing permissions of '/models/_triton_models/simple-string-167__ksp-a53a19561f': Operation not permitted
chmod: changing permissions of '/models/_triton_models/simple-string-167__ksp-a53a19561f/config.pbtxt': Operation not permitted
...
```
Since the `/models/_triton_models` dir contains files created by the adapter container which may run as a different user. Only the dir itself needs permissions set so that the adapter can write to it after it's first created.

#### Modifications

Remove `-R` from chmod command in `triton-2.x` ServingRuntime yaml.

#### Result

Avoid unnecessary errors in the log