### PR TITLE
Add component versions doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For help, please open an issue in this repository.
 
 ## Components and their Repositories
 
-ModelMesh Serving currently comprises components spread over a number of repositories.
+ModelMesh Serving currently comprises components spread over a number of repositories. The supported versions for the latest release are documented [here](./docs/component-versions.md).
 
 ![Architecture Image](./docs/images/0.2.0-highlevel.png)
 

--- a/docs/component-versions.md
+++ b/docs/component-versions.md
@@ -1,0 +1,8 @@
+# Component versions
+
+The following table shows the component versions for the latest modelmesh-serving release
+| Component | Description | Upstream Revision |
+| - | - | - |
+| ModelMesh | Serves as a general-purpose model serving management/routing layer | [v0.7.0](https://github.com/kserve/modelmesh/tree/v0.7.0) |
+| ModelMesh Runtime Adapter | Contains the unified puller/runtime-adapter image | [v0.7.0](https://github.com/kserve/modelmesh-runtime-adapter/tree/v0.7.0) |
+| REST Proxy | Supports inference requests using KServe V2 REST Predict Protocol | [v0.1.0](https://github.com/kserve/rest-proxy/tree/v0.1.0) |


### PR DESCRIPTION
Add component versions doc so the dependent versions are clearly listed
and the doc should be updated for each release when needed.

#### Motivation

#### Modifications

#### Result
