### PR TITLE
fix: Add default REST port to runtime NetworkPolicy

### DIFF
--- a/config/rbac/networkpolicy-runtimes.yaml
+++ b/config/rbac/networkpolicy-runtimes.yaml
@@ -36,6 +36,8 @@ spec:
     - ports:
         - port: 8033
           protocol: TCP
+        - port: 8008
+          protocol: TCP
     # exposed for prometheus metrics
     - ports:
         - port: 2112


### PR DESCRIPTION
#### Motivation

I was testing on OpenShift, and could not curl the REST proxy using NodePort/LoadBalancer service unless I added the port to the network policy.

#### Modifications

Expose the default REST port in the ServingRuntime NetworkPolicy.

#### Result

I can curl an inference result on OpenShift using a NodePort service.