### PR TITLE
Update config for release v0.7.0

### DIFF
--- a/config/default/config-defaults.yaml
+++ b/config/default/config-defaults.yaml
@@ -18,7 +18,7 @@ podsPerRuntime: 2
 headlessService: true
 modelMeshImage:
   name: kserve/modelmesh
-  tag: latest
+  tag: v0.7.0
 modelMeshResources:
   requests:
     cpu: "300m"
@@ -31,7 +31,7 @@ restProxy:
   port: 8008
   image:
     name: kserve/rest-proxy
-    tag: latest
+    tag: v0.1.0
   resources:
     requests:
       cpu: "50m"
@@ -41,7 +41,7 @@ restProxy:
       memory: "512Mi"
 storageHelperImage:
   name: kserve/modelmesh-runtime-adapter
-  tag: latest
+  tag: v0.7.0
   command: ["/opt/app/puller"]
 storageHelperResources:
   requests:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -18,4 +18,4 @@ images:
   - name: modelmesh-controller
     newName: kserve/modelmesh-controller
     ## NOTE THIS SHOULD BE REPLACED WITH LATEST CONTROLLER IMAGE TAG
-    newTag: latest
+    newTag: v0.7.0-rc1


### PR DESCRIPTION
Update config for release v0.7.0 to use specific tags
* modelmesh: v0.7.0
* modelmesh-runtime-adapter: v0.7.0
* rest-proxy: v0.1.0

#### Motivation

#### Modifications

#### Result
