### PR TITLE
fix: Fix code errors reported by golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -200,6 +200,8 @@ linters-settings:
     enable-all: true
     # disable:
     #   - shadow
+    disable:
+      - fieldalignment
     disable-all: false
   unused:
     # treat code as a program (not a library) and report unused exported identifiers; default is false.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 repos:
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.32.0
+    rev: v1.42.1
     hooks:
       - id: golangci-lint
   - repo: https://github.com/pre-commit/mirrors-prettier

--- a/controllers/modelmesh/etcd.go
+++ b/controllers/modelmesh/etcd.go
@@ -39,8 +39,8 @@ func (m *Deployment) configureMMDeploymentForEtcdSecret(deployment *appsv1.Deplo
 			}
 
 			volumeMountExists := false
-			for i, volumeMount := range container.VolumeMounts {
-				if volumeMount.Name == etcdVolume {
+			for i := range container.VolumeMounts {
+				if container.VolumeMounts[i].Name == etcdVolume {
 					volumeMountExists = true
 					container.VolumeMounts[i].ReadOnly = true
 					container.VolumeMounts[i].MountPath = etcdMountPath

--- a/controllers/modelmesh/etcd.go
+++ b/controllers/modelmesh/etcd.go
@@ -39,11 +39,11 @@ func (m *Deployment) configureMMDeploymentForEtcdSecret(deployment *appsv1.Deplo
 			}
 
 			volumeMountExists := false
-			for _, volumeMount := range container.VolumeMounts {
+			for i, volumeMount := range container.VolumeMounts {
 				if volumeMount.Name == etcdVolume {
 					volumeMountExists = true
-					volumeMount.ReadOnly = true
-					volumeMount.MountPath = etcdMountPath
+					container.VolumeMounts[i].ReadOnly = true
+					container.VolumeMounts[i].MountPath = etcdMountPath
 				}
 			}
 			if !volumeMountExists {

--- a/pkg/mmesh/etcdrangewatcher.go
+++ b/pkg/mmesh/etcdrangewatcher.go
@@ -71,9 +71,9 @@ func (t KeyEventType) String() string {
 }
 
 type KeyEvent struct {
-	Type  KeyEventType
 	Key   string
 	Value []byte
+	Type  KeyEventType
 }
 
 type KeyEventChan chan KeyEvent
@@ -100,7 +100,7 @@ func (r *EtcdRangeWatcher) Start(ctx context.Context, keysOnly bool, listener Kv
 	log.Info("EtcdRangeWatcher starting")
 	go func() {
 		initSent := false
-		cache := make(map[string]cacheEntry)
+		cache := make(map[string]*cacheEntry)
 	refresh_loop:
 		for {
 			client := r.etcdClient
@@ -134,7 +134,7 @@ func (r *EtcdRangeWatcher) Start(ctx context.Context, keysOnly bool, listener Kv
 						for _, kv := range gr.Kvs {
 							k := key(kv, prefixBytes)
 							if current, ok := cache[k]; !ok || kv.ModRevision > current.kv.ModRevision {
-								cache[k] = cacheEntry{kv: kv, found: true}
+								cache[k] = &cacheEntry{kv: kv, found: true}
 								listener(UPDATE, k, kv.Value)
 							} else {
 								current.found = true
@@ -166,7 +166,7 @@ func (r *EtcdRangeWatcher) Start(ctx context.Context, keysOnly bool, listener Kv
 					k := key(kv, prefixBytes)
 					switch event.Type {
 					case etcd3kv.PUT:
-						cache[k] = cacheEntry{kv: kv}
+						cache[k] = &cacheEntry{kv: kv}
 						listener(UPDATE, k, kv.Value)
 					case etcd3kv.DELETE:
 						if prev, ok := cache[k]; ok {


### PR DESCRIPTION
#### Motivation
In #53 reported some issues, checked and fixed the ones that are code errors

#### Modifications
Fix bug

#### Result
The code error is fixed, but
- The field alignment is not fixed, not sure whether it's needed and it may have potential impact, maybe just change the golangci-lint rule to ignore it?
- Does not upgrade golangci-lint to 1.42.1 and golang to 1.7 since as mentioned it will be looked separately.