### PR TITLE
chore: Update mlserver version in default runtime

### DIFF
--- a/.github/workflows/run-fvt.yml
+++ b/.github/workflows/run-fvt.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Pre-pull runtime images
         run: |
           docker pull nvcr.io/nvidia/tritonserver:21.06.1-py3
-          docker pull seldonio/mlserver:0.3.2
+          docker pull seldonio/mlserver:0.5.2
       - name: Check installation
         run: |
           docker images

--- a/config/runtimes/kustomization.yaml
+++ b/config/runtimes/kustomization.yaml
@@ -22,7 +22,7 @@ images:
 
   - name: mlserver-0
     newName: seldonio/mlserver
-    newTag: 0.3.2
+    newTag: 0.5.2
 
 transformers:
   - ../default/metadataLabelTransformer.yaml

--- a/fvt/inference.go
+++ b/fvt/inference.go
@@ -92,13 +92,7 @@ func ExpectSuccessfulInference_sklearnMnistSvm(predictorName string) {
 
 	// this example model takes 8x8 floating point images as input flattened
 	// to a 64 float array
-	image := []float32{
-		0., 0., 1., 11., 14., 15., 3., 0., 0., 1., 13., 16., 12.,
-		16., 8., 0., 0., 8., 16., 4., 6., 16., 5., 0., 0., 5.,
-		15., 11., 13., 14., 0., 0., 0., 0., 2., 12., 16., 13., 0.,
-		0., 0., 0., 0., 13., 16., 16., 6., 0., 0., 0., 0., 16.,
-		16., 16., 7., 0., 0., 0., 0., 11., 13., 12., 1., 0.,
-	}
+	image := []float32{0.0, 0.0, 1.0, 11.0, 14.0, 15.0, 3.0, 0.0, 0.0, 1.0, 13.0, 16.0, 12.0, 16.0, 8.0, 0.0, 0.0, 8.0, 16.0, 4.0, 6.0, 16.0, 5.0, 0.0, 0.0, 5.0, 15.0, 11.0, 13.0, 14.0, 0.0, 0.0, 0.0, 0.0, 2.0, 12.0, 16.0, 13.0, 0.0, 0.0, 0.0, 0.0, 0.0, 13.0, 16.0, 16.0, 6.0, 0.0, 0.0, 0.0, 0.0, 16.0, 16.0, 16.0, 7.0, 0.0, 0.0, 0.0, 0.0, 11.0, 13.0, 12.0, 1.0, 0.0}
 
 	inferInput := &inference.ModelInferRequest_InferInputTensor{
 		Name:     "predict",
@@ -116,7 +110,9 @@ func ExpectSuccessfulInference_sklearnMnistSvm(predictorName string) {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(inferResponse).ToNot(BeNil())
 	Expect(inferResponse.ModelName).To(HavePrefix(predictorName))
-	Expect(inferResponse.Outputs[0].Contents.Fp32Contents[0]).To(BeEquivalentTo(8))
+	Expect(inferResponse.Outputs).To(Not(BeEmpty()))
+	Expect(inferResponse.Outputs[0].Contents.Int64Contents).To(Not(BeEmpty()))
+	Expect(inferResponse.Outputs[0].Contents.Int64Contents[0]).To(BeEquivalentTo(8))
 }
 
 // Tensorflow MNIST
@@ -163,7 +159,7 @@ func ExpectSuccessfulInference_lightgbmMushroom(predictorName string) {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(inferResponse).ToNot(BeNil())
 	// check that the model predicted a value close to 0
-	Expect(math.Round(float64(inferResponse.Outputs[0].Contents.Fp32Contents[0])*10) / 10).To(BeEquivalentTo(0.0))
+	Expect(math.Round(float64(inferResponse.Outputs[0].Contents.Fp64Contents[0])*10) / 10).To(BeEquivalentTo(0.0))
 }
 
 // XGBoost Mushroom

--- a/fvt/predictor_test.go
+++ b/fvt/predictor_test.go
@@ -641,7 +641,7 @@ var _ = Describe("Predictor", func() {
 
 			Expect(inferResponse).To(BeNil())
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("INVALID_ARGUMENT: Invalid input to LightGBM"))
+			Expect(err.Error()).To(ContainSubstring("Unexpected <class 'ValueError'>: cannot reshape array"))
 		})
 	})
 


### PR DESCRIPTION
#### Motivation

MLServer has come out with several new versions, so we should update our default MLServer serving runtime to use a later version.

#### Modifications
The mlserver image version is updated from 0.3.2 to 0.5.2 in the mlserver default serving runtime. FVTs were also adjusted to accommodate this update.

#### Result
The default MLServer serving runtime will now deploy using the 0.5.2 mlserver image.

Closes: #60 