### PR TITLE
WIP: Add multi-namespace support

### DIFF
--- a/config/default/config-defaults.yaml
+++ b/config/default/config-defaults.yaml
@@ -50,6 +50,6 @@ storageHelperResources:
   limits:
     cpu: "2"
     memory: "512Mi"
-serviceAccountName: modelmesh
+serviceAccountName: ""
 metrics:
   enabled: true

--- a/config/dependencies/user_ns.yaml
+++ b/config/dependencies/user_ns.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+
+kind: Secret
+metadata:
+  name: storage-config
+stringData:
+  localMinIO: |
+    {
+      "type": "s3",
+      "access_key_id": "AKIAIOSFODNN7EXAMPLE",
+      "secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+      "endpoint_url": "http://minio.controller_namespace:9000",
+      "default_bucket": "modelmesh-example-models",
+      "region": "us-south"
+    }

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: controller-role
 rules:
@@ -21,6 +21,8 @@ rules:
       - ""
     resources:
       - configmaps
+      - services
+      - namespaces
     verbs:
       - create
       - delete
@@ -42,8 +44,12 @@ rules:
     resources:
       - secrets
     verbs:
+      - create
+      - delete
       - get
       - list
+      - patch
+      - update
       - watch
   - apiGroups:
       - ""

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: controller-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: controller-role
 subjects:
   - kind: ServiceAccount

--- a/controllers/predictor_controller.go
+++ b/controllers/predictor_controller.go
@@ -62,14 +62,14 @@ type PredictorReconciler struct {
 	RegistryLookup map[string]predictor_source.PredictorRegistry
 }
 
-// +kubebuilder:rbac:namespace=model-serving,groups=serving.kserve.io,resources=predictors,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:namespace=model-serving,groups=serving.kserve.io,resources=predictors/finalizers,verbs=get;update;patch
-// +kubebuilder:rbac:namespace=model-serving,groups=serving.kserve.io,resources=predictors/status,verbs=get;update;patch
-// +kubebuilder:rbac:namespace=model-serving,groups=serving.kserve.io,resources=inferenceservices,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:namespace=model-serving,groups=serving.kserve.io,resources=inferenceservices/finalizers,verbs=get;update;patch
-// +kubebuilder:rbac:namespace=model-serving,groups=serving.kserve.io,resources=inferenceservices/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=serving.kserve.io,resources=predictors,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=serving.kserve.io,resources=predictors/finalizers,verbs=get;update;patch
+// +kubebuilder:rbac:groups=serving.kserve.io,resources=predictors/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=serving.kserve.io,resources=inferenceservices,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=serving.kserve.io,resources=inferenceservices/finalizers,verbs=get;update;patch
+// +kubebuilder:rbac:groups=serving.kserve.io,resources=inferenceservices/status,verbs=get;update;patch
 // This one is used by the kube-based grpc resolver but need to set it here so that kubebuilder picks it up
-// +kubebuilder:rbac:namespace=model-serving,groups="",resources=endpoints,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=endpoints,verbs=get;list;watch
 
 func (pr *PredictorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	// if no explict source prefix we default to "ksp" (for Predictor CR)
@@ -83,6 +83,14 @@ func (pr *PredictorReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	return pr.ReconcilePredictor(ctx, nname, source, registry)
 }
 
+// Returns MMClient for a namespace
+func (pr *PredictorReconciler) getMMClient(namespace string) mmeshapi.ModelMeshClient {
+	if mms := pr.MMServices.Get(namespace); mms != nil {
+		return mms.MMClient()
+	}
+	return nil
+}
+
 func (pr *PredictorReconciler) ReconcilePredictor(ctx context.Context, nname types.NamespacedName,
 	sourceId string, registry predictor_source.PredictorRegistry) (ctrl.Result, error) {
 	resourceType := registry.GetSourceName()
@@ -93,6 +101,7 @@ func (pr *PredictorReconciler) ReconcilePredictor(ctx context.Context, nname typ
 	if (predictor == nil && err == nil) || errors.IsNotFound(err) {
 		return pr.handlePredictorNotFound(ctx, nname, sourceId)
 	}
+
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to fetch CR from kubebuilder cache for predictor %s: %w",
 			nname.Name, err)
@@ -101,10 +110,7 @@ func (pr *PredictorReconciler) ReconcilePredictor(ctx context.Context, nname typ
 	status := &predictor.Status
 	waitingBefore := status.WaitingForRuntime()
 	updateStatus := false
-	var mmc mmeshapi.ModelMeshClient
-	if mms := pr.MMServices.Get(nname.Namespace); mms != nil {
-		mmc = mms.MMClient()
-	}
+	mmc := pr.getMMClient(nname.Namespace)
 	var finalErr error
 	if predictor.Spec.Storage != nil && (predictor.Spec.Storage.S3 == nil || predictor.Spec.Storage.PersistentVolumeClaim != nil) {
 		log.Info("Only S3 Storage currently supported", "Storage", predictor.Spec.Storage)
@@ -243,10 +249,7 @@ var transitionStatusMap = map[mmeshapi.VModelStatusInfo_VModelStatus]api.Transit
 
 func (pr *PredictorReconciler) handlePredictorNotFound(ctx context.Context,
 	name types.NamespacedName, sourceId string) (ctrl.Result, error) {
-	var mmc mmeshapi.ModelMeshClient
-	if mms := pr.MMServices.Get(name.Namespace); mms != nil {
-		mmc = mms.MMClient()
-	}
+	mmc := pr.getMMClient(name.Namespace)
 	if mmc == nil {
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}

--- a/controllers/servingruntime_controller.go
+++ b/controllers/servingruntime_controller.go
@@ -29,12 +29,14 @@ package controllers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/kserve/modelmesh-serving/pkg/config"
 
+	"github.com/kserve/modelmesh-serving/pkg/mmesh"
 	"github.com/kserve/modelmesh-serving/pkg/predictor_source"
 
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -85,11 +87,11 @@ var builtInServerTypes = map[api.ServerType]interface{}{
 	api.MLServer: nil, api.Triton: nil,
 }
 
-// +kubebuilder:rbac:namespace="model-serving",groups=serving.kserve.io,resources=servingruntimes;servingruntimes/finalizers,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:namespace="model-serving",groups=serving.kserve.io,resources=servingruntimes/status,verbs=get;update;patch
-// +kubebuilder:rbac:namespace="model-serving",groups=apps,resources=deployments;deployments/finalizers,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:namespace="model-serving",groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:namespace="model-serving",groups="",resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups=serving.kserve.io,resources=servingruntimes;servingruntimes/finalizers,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=serving.kserve.io,resources=servingruntimes/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=apps,resources=deployments;deployments/finalizers,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 
 func (r *ServingRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("servingruntime", req.NamespacedName)
@@ -106,6 +108,10 @@ func (r *ServingRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		if err = r.Client.List(ctx, runtimes); err != nil {
 			return RequeueResult, err
 		}
+		//err := r.List(ctx, runtimes, client.InNamespace(req.Namespace))
+		//if err != nil {
+		//	return RequeueResult, err
+		//}
 	}
 
 	cc := modelmesh.ClusterConfig{Runtimes: runtimes, Scheme: r.Scheme}
@@ -117,6 +123,88 @@ func (r *ServingRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	//  read etcd secret from controller namespace, replace rootprefix with ns-specific one
 	//  and the create/update etcd secret (with same name) in _this_ namespace
 	//  and include an "ownership" label similar to the tc-config configmap
+
+	// Reconcile the model mesh cluster config map and etcd secret
+
+	// Delete etcd secret and configmap when there is no ServingRuntimes in a
+	// namespace
+	if len(runtimes.Items) == 0 {
+		// We don't delete the etcd secret in the controller namespace
+		if req.Namespace != r.ControllerNamespace {
+			s := &corev1.Secret{}
+			err = r.Client.Get(ctx, types.NamespacedName{
+				Name:      r.ConfigProvider.GetConfig().GetEtcdSecretName(),
+				Namespace: req.Namespace,
+			}, s)
+
+			if err == nil {
+				err = r.Delete(ctx, s)
+			} else if errors.IsNotFound(err) {
+				err = nil
+			}
+			if err != nil {
+				return RequeueResult, err
+			}
+		}
+
+		cm := &corev1.ConfigMap{}
+		err = r.Client.Get(ctx, types.NamespacedName{
+			Name:      modelmesh.InternalConfigMapName,
+			Namespace: req.Namespace,
+		}, cm)
+		if err == nil {
+			err = r.Delete(ctx, cm)
+		} else if errors.IsNotFound(err) {
+			err = nil
+		}
+
+		return RequeueResult, err
+	}
+
+	// cc := modelmesh.ClusterConfig{
+	// 	Runtimes:  runtimes,
+	// 	Namespace: req.Namespace,
+	// 	Scheme:    r.Scheme,
+	// }
+
+	// if err = cc.Apply(ctx, r.Client); err != nil {
+	// 	return RequeueResult, fmt.Errorf("Could not apply the modelmesh type-constraints configmap: %w", err)
+	// }
+
+	// If not controller namespace then read etcd secret from controller namespace,
+	// replace rootprefix with ns-specific one, and then create/update etcd secret (with same name)
+	// in _this_ namespace and include labels similar to the tc-config configmap
+
+	if req.Namespace != r.ControllerNamespace {
+		// get the controller secret
+		s := &corev1.Secret{}
+		err = r.Client.Get(ctx, types.NamespacedName{
+			Name:      r.ConfigProvider.GetConfig().GetEtcdSecretName(),
+			Namespace: r.ControllerNamespace,
+		}, s)
+		if err != nil {
+			return RequeueResult, fmt.Errorf("Could not get the controller etcd secret: %w", err)
+		}
+
+		data := s.Data[modelmesh.EtcdSecretKey]
+		etcdConfig := mmesh.EtcdConfig{}
+		if err = json.Unmarshal(data, &etcdConfig); err != nil {
+			return RequeueResult, fmt.Errorf("failed to parse etcd config json: %w", err)
+		}
+
+		es := mmesh.EtcdSecret{
+			Log:                 ctrl.Log.WithName("etcdSecret"),
+			Name:                r.ConfigProvider.GetConfig().GetEtcdSecretName(),
+			Namespace:           req.Namespace,
+			ControllerNamespace: r.ControllerNamespace,
+			EtcdConfig:          &etcdConfig,
+			Scheme:              r.Scheme,
+		}
+
+		if err = es.Apply(ctx, r.Client); err != nil {
+			return RequeueResult, fmt.Errorf("Could not apply the modelmesh etcd secret: %w", err)
+		}
+	}
 
 	//reconcile this serving runtime
 	rt := &api.ServingRuntime{}
@@ -189,7 +277,9 @@ func (r *ServingRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return RequeueResult, fmt.Errorf("could not determine replicas: %w", err)
 	}
 	mmDeployment.Replicas = replicas
-	if err = mmDeployment.Apply(ctx); err != nil {
+	err = mmDeployment.Apply(ctx)
+
+	if err != nil {
 		if errors.IsConflict(err) {
 			// this can occur during normal operations if the deployment was updated
 			// during this reconcile loop
@@ -202,6 +292,7 @@ func (r *ServingRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 }
 
 func validateServingRuntimeSpec(rt *api.ServingRuntime) error {
+
 	if rt.Spec.BuiltInAdapter == nil {
 		return nil // nothing to check
 	}
@@ -223,7 +314,6 @@ func (r *ServingRuntimeReconciler) determineReplicasAndRequeueDuration(ctx conte
 	var err error
 	const scaledToZero = uint16(0)
 	scaledUp := r.determineReplicas(rt)
-
 	if !config.ScaleToZero.Enabled {
 		return scaledUp, time.Duration(0), nil
 	}
@@ -292,6 +382,7 @@ func (r *ServingRuntimeReconciler) determineReplicasAndRequeueDuration(ctx conte
 }
 
 func (r *ServingRuntimeReconciler) determineReplicas(rt *api.ServingRuntime) uint16 {
+
 	if rt.Spec.Replicas == nil {
 		return r.ConfigProvider.GetConfig().PodsPerRuntime
 	}
@@ -326,6 +417,7 @@ func runtimeSupportsPredictor(rt *api.ServingRuntime, p *api.Predictor) bool {
 //
 // A predictor may be supported by multiple runtimes.
 func (r *ServingRuntimeReconciler) getRuntimesSupportingPredictor(ctx context.Context, p *api.Predictor) ([]types.NamespacedName, error) {
+
 	// list all runtimes
 	runtimes := &api.ServingRuntimeList{}
 	if err := r.Client.List(ctx, runtimes, client.InNamespace(p.Namespace)); err != nil {
@@ -336,10 +428,11 @@ func (r *ServingRuntimeReconciler) getRuntimesSupportingPredictor(ctx context.Co
 	for i := range runtimes.Items {
 		rt := &runtimes.Items[i]
 		if runtimeSupportsPredictor(rt, p) {
-			srnns = append(srnns, types.NamespacedName{
+			srnn := types.NamespacedName{
 				Name:      rt.GetName(),
 				Namespace: p.Namespace,
-			})
+			}
+			srnns = append(srnns, srnn)
 		}
 	}
 

--- a/controllers/servingruntime_controller.go
+++ b/controllers/servingruntime_controller.go
@@ -96,7 +96,7 @@ func (r *ServingRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	log.V(1).Info("ServingRuntime reconciler called")
 
 	// Make sure the namespace has serving enabled
-	mmEnabled, err := modelMeshEnabled(ctx, req.Namespace, r.ControllerNamespace, r.Client, r.HasNamespaceAccess)
+	mmEnabled, err := modelMeshEnabled2(ctx, req.Namespace, r.ControllerNamespace, r.Client, r.HasNamespaceAccess)
 	if err != nil {
 		return RequeueResult, err
 	}
@@ -356,7 +356,7 @@ func (r *ServingRuntimeReconciler) SetupWithManager(mgr ctrl.Manager,
 		Watches(&source.Kind{Type: &corev1.ConfigMap{}},
 			config.ConfigWatchHandler(r.ConfigMapName, func() []reconcile.Request {
 				return r.requestsForRuntimes("", func(rt *api.ServingRuntime) bool {
-					mme, err := modelMeshEnabled(context.TODO(), rt.GetNamespace(),
+					mme, err := modelMeshEnabled2(context.TODO(), rt.GetNamespace(),
 						r.ControllerNamespace, r.Client, r.HasNamespaceAccess)
 					return err != nil || mme // in case of error just reconcile anyhow
 				})

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -12,9 +12,11 @@
 
 We provide an install script to quickly run ModelMesh Serving with a provisioned etcd server. This may be useful for experimentation or development but should not be used in production.
 
-## Namespace Scope
+## Cluster Scope
 
-ModelMesh Serving is namespace scoped, meaning all of its components must exist within a single namespace and only one instance of ModelMesh Serving can be installed per namespace. Multiple ModelMesh Serving instances can be installed in separate namespaces within the cluster.
+ModelMesh Serving is cluster scoped, meaning its components can exist in multiple user namespaces which are controlled by one instance of ModelMesh Serving Controller in the control plane namespace. Only one ModelMesh Serving Controller instance can be installed within a Kubernetes cluster.
+
+A namespace label `modelmesh-enabled` needs to be "true" to enable a user namespace for ModelMesh Serving.
 
 ## Deployed Components
 
@@ -55,11 +57,14 @@ Please be aware that:
 
 For more details see the [built-in runtime configuration](../configuration/built-in-runtimes.md)
 
-In addition, the following resources will be created in the same namespace:
+In addition, the following resources will be created in the control plane namespace:
 
 - `model-serving-defaults` - ConfigMap holding default values tied to a release, should not be modified. Configuration can be overriden by creating a user ConfigMap, see [configuration](../configuration)
 - `tc-config` - ConfigMap used for some internal coordination
 - `storage-config` - Secret holding config for each of the storage backends from which models can be loaded - see [the example](../predictors/)
+- `model-serving-etcd` - Secret providing access to the Etcd cluster - see [instructions](../install/install-script.md#setup-the-etcd-connection-information)
+
+And the following resources will be created in a user namespace, `tc-config`, `storage-config`, and `model-serving-etcd`.
 
 ## Next Steps
 

--- a/main.go
+++ b/main.go
@@ -190,7 +190,6 @@ func main() {
 	mgrOpts := ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     metricsAddr,
-		Namespace:              ControllerNamespace,
 		Port:                   9443,
 		HealthProbeBindAddress: probeAddr,
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -324,7 +324,7 @@ func defaults(v *viper.Viper) {
 	v.SetDefault("InferenceServicePort", 8033)
 	v.SetDefault("PodsPerRuntime", 2)
 	v.SetDefault("StorageSecretName", "storage-config")
-	v.SetDefault("ServiceAccountName", "modelmesh")
+	v.SetDefault("ServiceAccountName", "")
 	v.SetDefault("Metrics.Port", 2112)
 	v.SetDefault("Metrics.Scheme", "https")
 	v.SetDefault("ScaleToZero.Enabled", true)

--- a/pkg/mmesh/etcd_secret.go
+++ b/pkg/mmesh/etcd_secret.go
@@ -1,0 +1,135 @@
+// Copyright 2021 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package mmesh
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	EtcdConnectionKey        = "etcd_connection"
+	EndpointsKey             = "endpoints"
+	UsernameKey              = "userid"
+	PasswordKey              = "password"
+	RootPrefixKey            = "root_prefix"
+	CertificateKey           = "certificate"
+	CertificateFileKey       = "certificate_file"
+	ClientKeyKey             = "client_key"
+	ClientKeyFileKey         = "client_key_file"
+	ClientCertificateKey     = "client_certificate"
+	ClientCertificateFileKey = "client_certificate_file"
+	OverrideAuthorityKey     = "override_authority"
+)
+
+// An EtcdSecret represents the etcd configuation for a
+// user namespace
+type EtcdSecret struct {
+	Log                 logr.Logger
+	Name                string
+	Namespace           string
+	ControllerNamespace string
+	EtcdConfig          *EtcdConfig
+	Scheme              *runtime.Scheme
+}
+
+func (es EtcdSecret) Apply(ctx context.Context, cl client.Client) error {
+	commonLabelValue := "modelmesh-controller"
+
+	s := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      es.Name,
+			Namespace: es.Namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": commonLabelValue,
+			},
+		},
+	}
+	es.addStringData(s)
+	err := cl.Create(ctx, s)
+	if err != nil && errors.IsAlreadyExists(err) {
+		err = cl.Update(ctx, s)
+	}
+
+	return err
+}
+
+// Add string data to the provided secret
+func (es EtcdSecret) addStringData(s *corev1.Secret) {
+	m := make(map[string]interface{})
+	// debugging, remove later
+	es.Log.Info("============in EtcdSecret=========", "es.EtcdConfig", es.EtcdConfig)
+
+	etcdEndpoints := strings.Split(es.EtcdConfig.Endpoints, ",")
+
+	newEtcdEndpoints := ""
+	// For each endpoint, insert controller namespace if not there
+	// TODO: revisit and come up with ideal solution
+	for i := range etcdEndpoints {
+		if !strings.Contains(etcdEndpoints[i], ".") {
+			// This looks like http://etcd:2379, so insert controller namespace before :port
+			parts := strings.Split(etcdEndpoints[i], ":")
+			etcdEndpoints[i] = parts[0] + ":" + parts[1] + "." + es.ControllerNamespace + ":" + parts[2]
+		}
+		if i != 0 {
+			newEtcdEndpoints = newEtcdEndpoints + ","
+		}
+		newEtcdEndpoints = newEtcdEndpoints + etcdEndpoints[i]
+	}
+
+	m[EndpointsKey] = newEtcdEndpoints
+	m[RootPrefixKey] = fmt.Sprintf("%s/mm_ns/%s", es.EtcdConfig.RootPrefix, es.Namespace)
+	if es.EtcdConfig.Username != "" {
+		m[UsernameKey] = es.EtcdConfig.Username
+	}
+	if es.EtcdConfig.Password != "" {
+		m[PasswordKey] = es.EtcdConfig.Password
+	}
+	if es.EtcdConfig.Certificate != "" {
+		m[CertificateKey] = es.EtcdConfig.Certificate
+	}
+	if es.EtcdConfig.CertificateFile != "" {
+		m[CertificateFileKey] = es.EtcdConfig.CertificateFile
+	}
+	if es.EtcdConfig.ClientKey != "" {
+		m[ClientKeyKey] = es.EtcdConfig.ClientKey
+	}
+	if es.EtcdConfig.ClientKeyFile != "" {
+		m[ClientKeyFileKey] = es.EtcdConfig.ClientKeyFile
+	}
+	if es.EtcdConfig.ClientCertificate != "" {
+		m[ClientCertificateKey] = es.EtcdConfig.ClientCertificate
+	}
+	if es.EtcdConfig.ClientCertificateFile != "" {
+		m[ClientCertificateFileKey] = es.EtcdConfig.ClientCertificateFile
+	}
+	if es.EtcdConfig.OverrideAuthority != "" {
+		m[OverrideAuthorityKey] = es.EtcdConfig.OverrideAuthority
+	}
+
+	t, _ := json.Marshal(m)
+	if s.StringData == nil {
+		s.StringData = make(map[string]string)
+	}
+	s.StringData[EtcdConnectionKey] = string(t)
+}

--- a/scripts/delete.sh
+++ b/scripts/delete.sh
@@ -19,6 +19,7 @@ set -Eeuo pipefail
 
 path_to_configs=config
 namespace=
+user_ns_array=
 
 function showHelp() {
   echo "usage: $0 [flags]"
@@ -26,6 +27,7 @@ function showHelp() {
   echo "Flags:"
   echo "  -p, --local-config-path      Path to local model serve installation configs. Can be ModelMesh Serving tarfile or directory."
   echo "  -n, --namespace              Kubernetes namespace where ModelMesh Serving is deployed."
+  echo "  -u, --user-namespaces        Kubernetes namespaces where ModelMesh Serving is enabled"
   echo
   echo "Deletes ModelMesh Serving CRDs, controller, and built-in runtimes into specified"
   echo "Kubernetes namespaces. Will use current Kube namespace and path if"
@@ -50,6 +52,10 @@ while (($# > 0)); do
   -n | --n | -namespace | --namespace)
     shift
     namespace="$1"
+    ;;
+  -u | --u | -user-namespaces | --user-namespaces)
+    shift
+    user_ns_array=($1)
     ;;
   -p | --p | -local-path | --local-path | -local-config-path | --local-config-path)
     shift
@@ -79,6 +85,24 @@ fi
 cd default
 kustomize edit set namespace "$namespace"
 cd ..
+
+if [[ ! -z $user_ns_array ]]; then
+  kustomize build runtimes --load-restrictor LoadRestrictionsNone > runtimes.yaml
+  cp dependencies/user_ns.yaml .
+  sed -i "s/controller_namespace/${namespace}/g" user_ns.yaml
+
+  for user_ns in "${user_ns_array[@]}"; do
+    if ! kubectl get namespaces $user_ns >/dev/null; then
+      echo "Kube namespace does not exist: $user_ns. Will skip."
+    else 
+      kubectl label namespace ${user_ns} modelmesh-enabled-
+      kubectl delete -f user_ns.yaml -n ${user_ns}
+      kubectl delete -f runtimes.yaml -n ${user_ns}
+    fi
+  done
+  rm user_ns.yaml
+  rm runtimes.yaml
+fi
 
 kustomize build default | kubectl delete -f - --ignore-not-found=true
 kustomize build runtimes --load-restrictor LoadRestrictionsNone | kubectl delete -f - --ignore-not-found=true

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -24,6 +24,7 @@ delete=false
 dev_mode_logging=false
 quickstart=false
 fvt=false
+user_ns_array=
 
 function showHelp() {
   echo "usage: $0 [flags]"
@@ -32,6 +33,7 @@ function showHelp() {
   echo "  -n, --namespace                (required) Kubernetes namespace to deploy ModelMesh Serving to."
   echo "  -p, --install-config-path      Path to local model serve installation configs. Can be ModelMesh Serving tarfile or directory."
   echo "  -d, --delete                   Delete any existing instances of ModelMesh Serving in Kube namespace before running install, including CRDs, RBACs, controller, older CRD with serving.kserve.io api group name, etc."
+  echo "  -u, --user-namespaces          Kubernetes namespaces to enable for ModelMesh Serving"
   echo "  --quickstart                   Install and configure required supporting datastores in the same namespace (etcd and MinIO) - for experimentation/development"
   echo "  --fvt                          Install and configure required supporting datastores in the same namespace (etcd and MinIO) - for development with fvt enabled"
   echo "  -dev, --dev-mode-logging       Enable dev mode logging (stacktraces on warning and no sampling)"
@@ -142,6 +144,10 @@ while (($# > 0)); do
   -n | --n | -namespace | --namespace)
     shift
     namespace="$1"
+    ;;
+  -u | --u | -user-namespaces | --user-namespaces)
+    shift
+    user_ns_array=($1)
     ;;
   -p | --p | -install-path | --install-path | -install-config-path | --install-config-path)
     shift
@@ -257,5 +263,23 @@ wait_for_pods_ready "-l control-plane=modelmesh-controller"
 
 info "Installing ModelMesh Serving built-in runtimes"
 kustomize build runtimes --load-restrictor LoadRestrictionsNone | kubectl apply -f -
+
+if [[ ! -z $user_ns_array ]]; then
+  kustomize build runtimes --load-restrictor LoadRestrictionsNone > runtimes.yaml
+  cp dependencies/user_ns.yaml .
+  sed -i "s/controller_namespace/${namespace}/g" user_ns.yaml
+
+  for user_ns in "${user_ns_array[@]}"; do
+    if ! kubectl get namespaces $user_ns >/dev/null; then
+      echo "Kube namespace does not exist: $user_ns. Will skip."
+    else 
+      kubectl label namespace ${user_ns} modelmesh-enabled="true"
+      kubectl apply -f user_ns.yaml -n ${user_ns}
+      kubectl apply -f runtimes.yaml -n ${user_ns}
+    fi
+  done
+  rm user_ns.yaml
+  rm runtimes.yaml
+fi
 
 success "Successfully installed ModelMesh Serving!"


### PR DESCRIPTION
Add multi-namespace support so one controller can manage resources
such as ServingRuntimes and Predictors in multiple namespaces

Signed-off-by: Chin Huang <chhuang@us.ibm.com>

#### Motivation
This PR is to add the multiple namespace support as described in https://github.com/kserve/modelmesh-serving/issues/33, and documented in https://docs.google.com/document/d/12Fscl9yEjDrOAqNEyRhA23MlqUYiHSDOP6XNi5lQYGA/edit#heading=h.6oqyeffyxm7q

#### Modifications
In phase one, we will make the controller to work with multiple namespaces while leave ServingRuntimes as namespaced. The changes are 
1. controllers to keep track of multiple namespaces
2. resolver to work with multiple namespaces
3. modelmesh to take namespace as part of service endpoints
4. rbac to be cluster scope
5. lifecycle support for service, etcd secret, and internal configmap
6. scripts and docs

#### Result
User can install modelmesh-serving once in a controller namespace and deploy ServingRuntimes and Predictors into multiple user namespaces
