### PR TITLE
chore: Update MLServer SR to increase max grpc msg size

### DIFF
--- a/config/runtimes/mlserver-0.x.yaml
+++ b/config/runtimes/mlserver-0.x.yaml
@@ -50,6 +50,9 @@ spec:
         # Set server addr to localhost to ensure MLServer only listen inside the pod
         - name: MLSERVER_HOST
           value: "127.0.0.1"
+        # Increase gRPC max message size to 16 MiB to support larger payloads
+        - name: MLSERVER_GRPC_MAX_MESSAGE_LENGTH
+          value: "16777216"
       resources:
         requests:
           cpu: 500m

--- a/controllers/testdata/servingruntime_controller.golden
+++ b/controllers/testdata/servingruntime_controller.golden
@@ -156,6 +156,8 @@ spec:
           value: dummy-model-fixme
         - name: MLSERVER_HOST
           value: 127.0.0.1
+        - name: MLSERVER_GRPC_MAX_MESSAGE_LENGTH
+          value: "16777216"
         image: mlserver-0:replace
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -401,6 +403,8 @@ spec:
           value: dummy-model-fixme
         - name: MLSERVER_HOST
           value: 127.0.0.1
+        - name: MLSERVER_GRPC_MAX_MESSAGE_LENGTH
+          value: "16777216"
         image: mlserver-0:replace
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -669,6 +673,8 @@ spec:
           value: dummy-model-fixme
         - name: MLSERVER_HOST
           value: 127.0.0.1
+        - name: MLSERVER_GRPC_MAX_MESSAGE_LENGTH
+          value: "16777216"
         image: mlserver-0:replace
         imagePullPolicy: IfNotPresent
         lifecycle:


### PR DESCRIPTION
MLServer recently allowed the gRPC max message length to be configurable. This commit uses that variable to increase the max message length to 16 MiB which aligns with ModelMesh's default.

Reference: https://github.com/SeldonIO/MLServer/blob/release/0.5.x/mlserver/settings.py#L39

Closes: #62 

