### PR TITLE
Change RBAC to enable cluster scope

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: controller-role
 rules:
@@ -21,6 +21,7 @@ rules:
       - ""
     resources:
       - configmaps
+      - namespaces
     verbs:
       - create
       - delete
@@ -42,8 +43,12 @@ rules:
     resources:
       - secrets
     verbs:
+      - create
+      - delete
       - get
       - list
+      - patch
+      - update
       - watch
   - apiGroups:
       - ""

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -21,7 +21,6 @@ rules:
       - ""
     resources:
       - configmaps
-      - namespaces
     verbs:
       - create
       - delete
@@ -37,6 +36,16 @@ rules:
     verbs:
       - get
       - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - patch
+      - update
       - watch
   - apiGroups:
       - ""

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: controller-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: controller-role
 subjects:
   - kind: ServiceAccount

--- a/controllers/predictor_controller.go
+++ b/controllers/predictor_controller.go
@@ -63,14 +63,14 @@ type PredictorReconciler struct {
 	RegistryLookup map[string]predictor_source.PredictorRegistry
 }
 
-// +kubebuilder:rbac:namespace=model-serving,groups=serving.kserve.io,resources=predictors,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:namespace=model-serving,groups=serving.kserve.io,resources=predictors/finalizers,verbs=get;update;patch
-// +kubebuilder:rbac:namespace=model-serving,groups=serving.kserve.io,resources=predictors/status,verbs=get;update;patch
-// +kubebuilder:rbac:namespace=model-serving,groups=serving.kserve.io,resources=inferenceservices,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:namespace=model-serving,groups=serving.kserve.io,resources=inferenceservices/finalizers,verbs=get;update;patch
-// +kubebuilder:rbac:namespace=model-serving,groups=serving.kserve.io,resources=inferenceservices/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=serving.kserve.io,resources=predictors,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=serving.kserve.io,resources=predictors/finalizers,verbs=get;update;patch
+// +kubebuilder:rbac:groups=serving.kserve.io,resources=predictors/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=serving.kserve.io,resources=inferenceservices,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=serving.kserve.io,resources=inferenceservices/finalizers,verbs=get;update;patch
+// +kubebuilder:rbac:groups=serving.kserve.io,resources=inferenceservices/status,verbs=get;update;patch
 // This one is used by the kube-based grpc resolver but need to set it here so that kubebuilder picks it up
-// +kubebuilder:rbac:namespace=model-serving,groups="",resources=endpoints,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=endpoints,verbs=get;list;watch
 
 func (pr *PredictorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	// if no explict source prefix we default to "ksp" (for Predictor CR)

--- a/controllers/service_controller.go
+++ b/controllers/service_controller.go
@@ -119,6 +119,7 @@ func (r *ServiceReconciler) getMMService(namespace string,
 }
 
 // +kubebuilder:rbac:groups="",resources=services;services/finalizers,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups="monitoring.coreos.com",resources=servicemonitors,verbs=get;list;watch;create;update;patch;delete
 
 func (r *ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/controllers/service_controller.go
+++ b/controllers/service_controller.go
@@ -118,8 +118,8 @@ func (r *ServiceReconciler) getMMService(namespace string,
 	return mms, cp.GetConfig(), false
 }
 
-// +kubebuilder:rbac:namespace="model-serving",groups="",resources=services;services/finalizers,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:namespace="model-serving",groups="monitoring.coreos.com",resources=servicemonitors,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=services;services/finalizers,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="monitoring.coreos.com",resources=servicemonitors,verbs=get;list;watch;create;update;patch;delete
 
 func (r *ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	r.Log.V(1).Info("Service reconciler called", "name", req.NamespacedName)

--- a/controllers/servingruntime_controller.go
+++ b/controllers/servingruntime_controller.go
@@ -87,11 +87,11 @@ var builtInServerTypes = map[api.ServerType]interface{}{
 	api.MLServer: nil, api.Triton: nil,
 }
 
-// +kubebuilder:rbac:namespace="model-serving",groups=serving.kserve.io,resources=servingruntimes;servingruntimes/finalizers,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:namespace="model-serving",groups=serving.kserve.io,resources=servingruntimes/status,verbs=get;update;patch
-// +kubebuilder:rbac:namespace="model-serving",groups=apps,resources=deployments;deployments/finalizers,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:namespace="model-serving",groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:namespace="model-serving",groups="",resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups=serving.kserve.io,resources=servingruntimes;servingruntimes/finalizers,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=serving.kserve.io,resources=servingruntimes/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=apps,resources=deployments;deployments/finalizers,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 
 func (r *ServingRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("servingruntime", req.NamespacedName)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -25,7 +25,7 @@ dev_mode_logging=false
 quickstart=false
 fvt=false
 user_ns_array=
-namespace_scope_mode=true # default will be changed to false when rbac is changed to cluster scope
+namespace_scope_mode=false # change to true to run in namespace scope
 
 function showHelp() {
   echo "usage: $0 [flags]"


### PR DESCRIPTION
Change RBAC to enable cluster scope as the default mode
- role
- role binding
- install default

Signed-off-by: Chin Huang <chhuang@us.ibm.com>

#### Motivation
Make cluster scope as the default mode for the modelmesh serving controller, to be consistent with kserve

#### Modifications
RBAC roles and role binding
Install default is changed to cluster scope

#### Result
Controller will have cluster role and default installation is in cluster scope mode