### PR TITLE
feat: Introduce "multiModel" field to SR spec

### DIFF
--- a/apis/serving/v1alpha1/servingruntime_types.go
+++ b/apis/serving/v1alpha1/servingruntime_types.go
@@ -79,6 +79,11 @@ type ServingRuntimePodSpec struct {
 type ServingRuntimeSpec struct {
 	// Model formats and version supported by this runtime
 	SupportedModelTypes []ModelType `json:"supportedModelTypes,omitempty"`
+
+	// Whether this ServingRuntime is intended for multi-model usage or not.
+	// +optional
+	MultiModel *bool `json:"multiModel,omitempty"`
+
 	// Set to true to disable use of this runtime
 	// +optional
 	Disabled *bool `json:"disabled,omitempty"`
@@ -182,4 +187,8 @@ func init() {
 
 func (sr ServingRuntime) Disabled() bool {
 	return sr.Spec.Disabled != nil && *sr.Spec.Disabled
+}
+
+func (sr ServingRuntime) IsModelMeshCompatible() bool {
+	return sr.Spec.MultiModel != nil && *sr.Spec.MultiModel
 }

--- a/apis/serving/v1alpha1/servingruntime_types.go
+++ b/apis/serving/v1alpha1/servingruntime_types.go
@@ -189,6 +189,6 @@ func (sr ServingRuntime) Disabled() bool {
 	return sr.Spec.Disabled != nil && *sr.Spec.Disabled
 }
 
-func (sr ServingRuntime) IsModelMeshCompatible() bool {
+func (sr ServingRuntime) IsMultiModelRuntime() bool {
 	return sr.Spec.MultiModel != nil && *sr.Spec.MultiModel
 }

--- a/apis/serving/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/serving/v1alpha1/zz_generated.deepcopy.go
@@ -378,6 +378,11 @@ func (in *ServingRuntimeSpec) DeepCopyInto(out *ServingRuntimeSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.MultiModel != nil {
+		in, out := &in.MultiModel, &out.MultiModel
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Disabled != nil {
 		in, out := &in.Disabled, &out.Disabled
 		*out = new(bool)

--- a/config/crd/bases/serving.kserve.io_servingruntimes.yaml
+++ b/config/crd/bases/serving.kserve.io_servingruntimes.yaml
@@ -998,8 +998,9 @@ spec:
                         requests
                       type: integer
                     serverType:
-                      description: ServerType can be one of triton/mlserver and
-                        the runtime's container must have the same name
+                      description:
+                        ServerType can be one of triton/mlserver and the
+                        runtime's container must have the same name
                       enum:
                         - triton
                         - mlserver
@@ -1355,6 +1356,11 @@ spec:
                     mmesh.ModelRuntime gRPC service) Assumed to be single-model runtime
                     if omitted
                   type: string
+                multiModel:
+                  description:
+                    Whether this ServingRuntime is intended for multi-model
+                    usage or not.
+                  type: boolean
                 nodeSelector:
                   additionalProperties:
                     type: string

--- a/config/runtimes/mlserver-0.x.yaml
+++ b/config/runtimes/mlserver-0.x.yaml
@@ -26,6 +26,8 @@ spec:
     - name: lightgbm
       version: "3" # v3.2.1
 
+  multiModel: true
+
   grpcEndpoint: "port:8085"
   grpcDataEndpoint: "port:8001"
 

--- a/config/runtimes/triton-2.x.yaml
+++ b/config/runtimes/triton-2.x.yaml
@@ -32,6 +32,8 @@ spec:
     - name: onnx
       version: "1" # 1.5.3
 
+  multiModel: true
+
   grpcEndpoint: "port:8085"
   grpcDataEndpoint: "port:8001"
 

--- a/config/samples/servingruntime_pullerless.yaml
+++ b/config/samples/servingruntime_pullerless.yaml
@@ -21,6 +21,7 @@ spec:
         limits:
           cpu: "5"
           memory: 1Gi
+  multiModel: true
   grpcDataEndpoint: port:8001
   grpcEndpoint: port:8001
 

--- a/controllers/modelmesh/cluster_config.go
+++ b/controllers/modelmesh/cluster_config.go
@@ -109,7 +109,7 @@ func calculateConstraintData(rts []api.ServingRuntime) []byte {
 
 	m := make(map[string]interface{})
 	for _, rt := range rts {
-		if !rt.Disabled() {
+		if !rt.Disabled() && rt.IsModelMeshCompatible() {
 			labels := GetServingRuntimeSupportedModelTypeLabelSet(&rt)
 			// treat each label as a separate model type
 			for l := range labels {

--- a/controllers/modelmesh/cluster_config.go
+++ b/controllers/modelmesh/cluster_config.go
@@ -109,7 +109,7 @@ func calculateConstraintData(rts []api.ServingRuntime) []byte {
 
 	m := make(map[string]interface{})
 	for _, rt := range rts {
-		if !rt.Disabled() && rt.IsModelMeshCompatible() {
+		if !rt.Disabled() && rt.IsMultiModelRuntime() {
 			labels := GetServingRuntimeSupportedModelTypeLabelSet(&rt)
 			// treat each label as a separate model type
 			for l := range labels {

--- a/controllers/modelmesh/cluster_config_test.go
+++ b/controllers/modelmesh/cluster_config_test.go
@@ -24,6 +24,7 @@ func TestCalculateConstraintData(t *testing.T) {
 	expected := `{"_default":{"required":["_no_runtime"]},` +
 		`"mt:tensorflow":{"required":["mt:tensorflow"]},"mt:tensorflow:1.10":{"required":["mt:tensorflow:1.10"]},"rt:tf-serving-runtime":{"required":["rt:tf-serving-runtime"]}}`
 	v := "1.10"
+	mm := true
 	l := api.ServingRuntimeList{
 		Items: []api.ServingRuntime{
 			{
@@ -37,6 +38,7 @@ func TestCalculateConstraintData(t *testing.T) {
 							Version: &v,
 						},
 					},
+					MultiModel: &mm,
 				},
 			},
 		},

--- a/controllers/servingruntime_controller.go
+++ b/controllers/servingruntime_controller.go
@@ -225,7 +225,7 @@ func (r *ServingRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	// if the runtime is disabled, delete the deployment
-	if rt.Disabled() || !rt.IsModelMeshCompatible() || !mmEnabled {
+	if rt.Disabled() || !rt.IsMultiModelRuntime() || !mmEnabled {
 		log.Info("Runtime is disabled, incompatible with modelmesh, or namespace is not modelmesh-enabled")
 		if err = mmDeployment.Delete(ctx, r.Client); err != nil {
 			return ctrl.Result{}, fmt.Errorf("could not delete the model mesh deployment: %w", err)
@@ -384,7 +384,7 @@ func (r *ServingRuntimeReconciler) getRuntimesSupportingPredictor(ctx context.Co
 	srnns := make([]types.NamespacedName, 0, len(runtimes.Items))
 	for i := range runtimes.Items {
 		rt := &runtimes.Items[i]
-		if rt.IsModelMeshCompatible() && runtimeSupportsPredictor(rt, p) {
+		if rt.IsMultiModelRuntime() && runtimeSupportsPredictor(rt, p) {
 			srnns = append(srnns, types.NamespacedName{
 				Name:      rt.GetName(),
 				Namespace: p.Namespace,

--- a/controllers/servingruntime_controller.go
+++ b/controllers/servingruntime_controller.go
@@ -225,8 +225,8 @@ func (r *ServingRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	// if the runtime is disabled, delete the deployment
-	if rt.Disabled() || !mmEnabled {
-		log.Info("Runtime is disabled or namespace is not modelmesh-enabled")
+	if rt.Disabled() || !rt.IsModelMeshCompatible() || !mmEnabled {
+		log.Info("Runtime is disabled, incompatible with modelmesh, or namespace is not modelmesh-enabled")
 		if err = mmDeployment.Delete(ctx, r.Client); err != nil {
 			return ctrl.Result{}, fmt.Errorf("could not delete the model mesh deployment: %w", err)
 		}
@@ -384,7 +384,7 @@ func (r *ServingRuntimeReconciler) getRuntimesSupportingPredictor(ctx context.Co
 	srnns := make([]types.NamespacedName, 0, len(runtimes.Items))
 	for i := range runtimes.Items {
 		rt := &runtimes.Items[i]
-		if runtimeSupportsPredictor(rt, p) {
+		if rt.IsModelMeshCompatible() && runtimeSupportsPredictor(rt, p) {
 			srnns = append(srnns, types.NamespacedName{
 				Name:      rt.GetName(),
 				Namespace: p.Namespace,

--- a/controllers/testdata/test-servingruntime.yaml
+++ b/controllers/testdata/test-servingruntime.yaml
@@ -6,6 +6,7 @@ spec:
   supportedModelTypes:
     - name: test
 
+  multiModel: true
   grpcEndpoint: "port:8000"
   grpcDataEndpoint: "port:8001"
 

--- a/docs/runtimes/custom_runtimes.md
+++ b/docs/runtimes/custom_runtimes.md
@@ -194,6 +194,7 @@ spec:
   containers:
     - name: model-server
       image: samplemodelserver:latest
+  multiModel: true
   grpcEndpoint: "port:8085"
   grpcDataEndpoint: "port:8090"
 ```
@@ -220,6 +221,7 @@ Available attributes in the `ServingRuntime` spec:
 
 | Attribute                        | Description                                                                                                                                                               |
 | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `multiModel`                     | Whether this ServingRuntime is ModelMesh-compatible and intended for multi-model usage (as opposed to KServe single-model serving).                                       |
 | `disable`                        | Disables this runtime                                                                                                                                                     |
 | `containers`                     | List of containers associated with the runtime                                                                                                                            |
 | `containers[ ].image`            | The container image for the current container                                                                                                                             |
@@ -285,6 +287,7 @@ spec:
           memory: 200Mi
       imagePullPolicy: IfNotPresent
       workingDir: "/container/working/dir"
+  multiModel: true
   disabled: false
   storageHelper:
     disabled: true

--- a/docs/runtimes/mlserver_custom.md
+++ b/docs/runtimes/mlserver_custom.md
@@ -138,6 +138,7 @@ spec:
     modelLoadingTimeoutMillis: 90000
     runtimeManagementPort: 8001
     serverType: mlserver
+  multiModel: true
   grpcDataEndpoint: port:8001
   grpcEndpoint: port:8085
   containers:

--- a/fvt/fvtclient.go
+++ b/fvt/fvtclient.go
@@ -153,6 +153,12 @@ func (fvt *FVTClient) ApplyPredictorExpectSuccess(predictor *unstructured.Unstru
 	return obj
 }
 
+func (fvt *FVTClient) GetServingRuntime(name string) *unstructured.Unstructured {
+	obj, err := fvt.Resource(gvrRuntime).Namespace(fvt.namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	Expect(err).ToNot(HaveOccurred())
+	return obj
+}
+
 func (fvt *FVTClient) ListServingRuntimes(options metav1.ListOptions) (*unstructured.UnstructuredList, error) {
 	return fvt.Resource(gvrRuntime).Namespace(fvt.namespace).List(context.TODO(), options)
 }

--- a/fvt/globals.go
+++ b/fvt/globals.go
@@ -27,4 +27,5 @@ const (
 	DefaultTestServiceName = "modelmesh-serving"
 	userConfigMapName      = "model-serving-config"
 	samplesPath            = "testdata/predictors/"
+	runtimeSamplesPath     = "testdata/runtimes/"
 )

--- a/fvt/predictor_test.go
+++ b/fvt/predictor_test.go
@@ -930,8 +930,12 @@ var _ = Describe("Non-ModelMesh ServingRuntime", func() {
 		obj = fvtClient.GetPredictor(obj.GetName())
 
 		By("Verifying the predictor has failure message")
-		ExpectPredictorFailureInfo(obj, "RuntimeUnhealthy", false, false,
-			"Waiting for runtime Pod to become available")
+		failureInfo := GetMap(obj, "status", "lastFailureInfo")
+		Expect(failureInfo).ToNot(BeNil())
+
+		// Failure reason depends on if a ModelMesh container is up (i.e. a SR pod is running).
+		// Here, just check for one of the expected failure reasons.
+		Expect(failureInfo["reason"]).To(Or(Equal("RuntimeUnhealthy"), Equal("NoSupportingRuntime")))
 
 		fvtClient.DeletePredictor(obj.GetName())
 	})

--- a/fvt/testdata/predictors/foo-predictor.yaml
+++ b/fvt/testdata/predictors/foo-predictor.yaml
@@ -1,0 +1,24 @@
+# Copyright 2021 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: serving.kserve.io/v1alpha1
+kind: Predictor
+metadata:
+  name: foo-predictor
+spec:
+  modelType:
+    name: foo
+  path: fvt/foo
+  storage:
+    s3:
+      secretKey: localMinIO

--- a/fvt/testdata/runtimes/non-mm-runtime.yaml
+++ b/fvt/testdata/runtimes/non-mm-runtime.yaml
@@ -14,29 +14,20 @@
 apiVersion: serving.kserve.io/v1alpha1
 kind: ServingRuntime
 metadata:
-  name: custom-runtime-1.x
+  name: non-mm-runtime
 spec:
-  containers:
-    - env:
-        - name: MODEL_DIRECTORY_PATH
-          value: /models
-        - name: MODEL_SERVER_MEM_REQ_BYTES
-          valueFrom:
-            resourceFieldRef:
-              containerName: modelserver
-              resource: requests.memory
-      image: tnarayan74/custom-runtime:6.0
-      name: modelserver
-      resources:
-        limits:
-          cpu: "2"
-          memory: 1Gi
-        requests:
-          cpu: 500m
-          memory: 1Gi
-  multiModel: true
-  grpcDataEndpoint: port:8001
-  grpcEndpoint: port:8001
   supportedModelTypes:
-    - name: ml-type1
+    - name: foo
       version: "1"
+  containers:
+    - name: kserve-container
+      image: fo
+      args:
+        - --model_name=foo
+      resources:
+        requests:
+          cpu: "1"
+          memory: 2Gi
+        limits:
+          cpu: "1"
+          memory: 2Gi


### PR DESCRIPTION
#### Motivation
With KServe now using ServingRuntimes, we need to make sure that the ModelMesh-Serving runtime selection logic only selects runtimes that are ModelMesh compatible.

#### Modifications
This adds a field `multi-model` to the ServingRuntime spec which denotes if a given SR is compatible with ModelMesh or not. The default is false. ServingRuntime controller logic was adjusted to account for this field.  An e2e test was added to test this field, and example SRs in docs were updated to include this field.

#### Result

ModelMesh-Serving will only consider runtimes with multiModel = true, and SMS and MMS ServingRuntimes can coexist peacefully.

Close: https://github.com/kserve/modelmesh-serving/issues/80