### PR TITLE
Enable basic FVTs for multi namespaces

### DIFF
--- a/.github/workflows/run-fvt.yml
+++ b/.github/workflows/run-fvt.yml
@@ -51,7 +51,8 @@ jobs:
       - name: Install ModelMesh Serving
         run: |
           kubectl create ns modelmesh-serving
-          ./scripts/install.sh --namespace modelmesh-serving --fvt --dev-mode-logging
+          kubectl create ns modelmesh-user
+          ./scripts/install.sh --namespace modelmesh-serving -u modelmesh-user --fvt --dev-mode-logging
       - name: Pre-pull runtime images
         run: |
           docker pull nvcr.io/nvidia/tritonserver:21.06.1-py3
@@ -63,4 +64,7 @@ jobs:
           kubectl get servingruntimes
       - name: Run FVTs
         run: |
+          export NAMESPACE=modelmesh-serving
+          make fvt
+          export NAMESPACE=modelmesh-user
           make fvt

--- a/fvt/fvt_suite_test.go
+++ b/fvt/fvt_suite_test.go
@@ -52,10 +52,14 @@ var _ = BeforeSuite(func() {
 	if serviceName == "" {
 		serviceName = DefaultTestServiceName
 	}
-	log.Info("Using environment variables", "NAMESPACE", namespace, "SERVICENAME", serviceName)
+	controllerNamespace := os.Getenv("CONTROLLERNAMESPACE")
+	if controllerNamespace == "" {
+		controllerNamespace = DefaultControllerNamespace
+	}
+	log.Info("Using environment variables", "NAMESPACE", namespace, "SERVICENAME", serviceName, "CONTROLLERNAMESPACE", controllerNamespace)
 
 	var err error
-	fvtClient, err = GetFVTClient(log, namespace, serviceName)
+	fvtClient, err = GetFVTClient(log, namespace, serviceName, controllerNamespace)
 	Expect(err).ToNot(HaveOccurred())
 	log.Info("FVTClient created", "client", fvtClient)
 

--- a/fvt/globals.go
+++ b/fvt/globals.go
@@ -19,13 +19,14 @@ var log logr.Logger
 var fvtClient *FVTClient
 
 const (
-	ServingRuntimeKind     = "ServingRuntime"
-	PredictorKind          = "Predictor"
-	ConfigMapKind          = "ConfigMap"
-	SecretKind             = "Secret"
-	DefaultTestNamespace   = "modelmesh-serving"
-	DefaultTestServiceName = "modelmesh-serving"
-	userConfigMapName      = "model-serving-config"
-	samplesPath            = "testdata/predictors/"
-	runtimeSamplesPath     = "testdata/runtimes/"
+	ServingRuntimeKind         = "ServingRuntime"
+	PredictorKind              = "Predictor"
+	ConfigMapKind              = "ConfigMap"
+	SecretKind                 = "Secret"
+	DefaultTestNamespace       = "modelmesh-serving"
+	DefaultTestServiceName     = "modelmesh-serving"
+	DefaultControllerNamespace = "modelmesh-serving"
+	userConfigMapName          = "model-serving-config"
+	samplesPath                = "testdata/predictors/"
+	runtimeSamplesPath         = "testdata/runtimes/"
 )

--- a/fvt/predictor_test.go
+++ b/fvt/predictor_test.go
@@ -119,6 +119,7 @@ var _ = Describe("Predictor", func() {
 					"value": "0",
 				},
 			},
+			"podsPerRuntime": 1,
 		}
 		fvtClient.ApplyUserConfigMap(config)
 
@@ -788,6 +789,7 @@ var _ = Describe("Invalid Predictors", func() {
 					"value": "0",
 				},
 			},
+			"podsPerRuntime": 1,
 		}
 		fvtClient.ApplyUserConfigMap(config)
 
@@ -842,10 +844,7 @@ var _ = Describe("Invalid Predictors", func() {
 
 			It("predictor should fail to load with unsupported storage type", func() {
 				// modify the object with a PVC storage type, which isn't yet supported
-				err := unstructured.SetNestedField(predictorObject.Object, nil, "spec", "storage", "s3")
-				Expect(err).ToNot(HaveOccurred())
-
-				err = unstructured.SetNestedField(predictorObject.Object, map[string]interface{}{
+				err := unstructured.SetNestedField(predictorObject.Object, map[string]interface{}{
 					"claimName": "not-yet-supported",
 				}, "spec", "storage", "persistentVolumeClaim")
 				Expect(err).ToNot(HaveOccurred())

--- a/scripts/deploy/iks/test-fvt.sh
+++ b/scripts/deploy/iks/test-fvt.sh
@@ -40,13 +40,24 @@ run_fvt() {
   echo " =====   run standard fvt   ====="
   kubectl get all -n "$SERVING_NS"
   export KUBECONFIG=~/.kube/config
-    
+
+  rm -rf /usr/local/go
+  wget https://go.dev/dl/go1.17.3.linux-amd64.tar.gz
+  tar -C /usr/local -xzf go1.17.3.linux-amd64.tar.gz
+
+  export NAMESPACE=${SERVING_NS}
   go test -v ./fvt -ginkgo.v -ginkgo.progress -test.timeout 40m > fvt.out
   cat fvt.out
   RUN_STATUS=$(cat fvt.out | awk '{ print $1}' | grep PASS)
 
   if [[ "$RUN_STATUS" == "PASS" ]]; then
-    REV=0
+    export NAMESPACE="modelmesh-user"
+    go test -v ./fvt -ginkgo.v -ginkgo.progress -test.timeout 40m > fvt.out
+    cat fvt.out
+    RUN_STATUS=$(cat fvt.out | awk '{ print $1}' | grep PASS)
+    if [[ "$RUN_STATUS" == "PASS" ]]; then
+      REV=0
+    fi
   fi
 
   return "$REV"


### PR DESCRIPTION
Enable basic FVTs for multi namespaces
- add an env variable for controller namespace
- update model-serving-config in the controller namespace
- update FVT workflow to run complete FVTs in user namespace
  in addition to controller namespace

Signed-off-by: Chin Huang <chhuang@us.ibm.com>

#### Motivation
Enable and run FVTs in both controller and user namespaces in
the default cluster scope mode

#### Modifications
1. Updated fvt code to take an env variable for controller namespace
and configure configmap in the controller namespace.
2. Add/update script in workflow and setup and run FVTs in user namespace 

#### Result
The FVTs should run and pass in multiple namespaces