### PR TITLE
feat: Add autoSelect ServingRuntime logic

### DIFF
--- a/config/runtimes/mlserver-0.x.yaml
+++ b/config/runtimes/mlserver-0.x.yaml
@@ -21,10 +21,13 @@ spec:
   supportedModelFormats:
     - name: sklearn
       version: "0" # v0.23.1
+      autoSelect: true
     - name: xgboost
       version: "1" # v1.1.1
+      autoSelect: true
     - name: lightgbm
       version: "3" # v3.2.1
+      autoSelect: true
 
   multiModel: true
 

--- a/config/runtimes/triton-2.x.yaml
+++ b/config/runtimes/triton-2.x.yaml
@@ -23,14 +23,19 @@ spec:
   supportedModelFormats:
     - name: tensorflow
       version: "1" # 1.15.4
+      autoSelect: true
     - name: tensorflow
       version: "2" # 2.3.1
+      autoSelect: true
     - name: tensorrt
       version: "7" # 7.2.1
+      autoSelect: true
     - name: pytorch
       version: "1" # 1.8.0a0+17f8c32
+      autoSelect: true
     - name: onnx
       version: "1" # 1.5.3
+      autoSelect: true
 
   multiModel: true
 

--- a/config/samples/servingruntime_custom.yaml
+++ b/config/samples/servingruntime_custom.yaml
@@ -40,3 +40,4 @@ spec:
   supportedModelFormats:
     - name: ml-type1
       version: "1"
+      autoSelect: true

--- a/config/samples/servingruntime_pullerless.yaml
+++ b/config/samples/servingruntime_pullerless.yaml
@@ -32,3 +32,4 @@ spec:
   supportedModelFormats:
     - name: ml-type1
       version: "1"
+      autoSelect: true

--- a/controllers/modelmesh/cluster_config_test.go
+++ b/controllers/modelmesh/cluster_config_test.go
@@ -24,6 +24,8 @@ func TestCalculateConstraintData(t *testing.T) {
 	expected := `{"_default":{"required":["_no_runtime"]},` +
 		`"mt:tensorflow":{"required":["mt:tensorflow"]},"mt:tensorflow:1.10":{"required":["mt:tensorflow:1.10"]},"rt:tf-serving-runtime":{"required":["rt:tf-serving-runtime"]}}`
 	v := "1.10"
+	v2 := "2"
+	a := true
 	mm := true
 	l := api.ServingRuntimeList{
 		Items: []api.ServingRuntime{
@@ -34,8 +36,13 @@ func TestCalculateConstraintData(t *testing.T) {
 				Spec: api.ServingRuntimeSpec{
 					SupportedModelFormats: []api.SupportedModelFormat{
 						{
+							Name:       "tensorflow",
+							Version:    &v,
+							AutoSelect: &a,
+						},
+						{
 							Name:    "tensorflow",
-							Version: &v,
+							Version: &v2,
 						},
 					},
 					MultiModel: &mm,

--- a/controllers/modelmesh/constraints_test.go
+++ b/controllers/modelmesh/constraints_test.go
@@ -34,6 +34,7 @@ func TestCalculateLabel(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			v := "1"
+			a := true
 			rt := &api.ServingRuntime{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "tf-serving-runtime",
@@ -41,8 +42,9 @@ func TestCalculateLabel(t *testing.T) {
 				Spec: api.ServingRuntimeSpec{
 					SupportedModelFormats: []api.SupportedModelFormat{
 						{
-							Name:    "tensorflow",
-							Version: &v,
+							Name:       "tensorflow",
+							Version:    &v,
+							AutoSelect: &a,
 						},
 					},
 				},

--- a/controllers/modelmesh/model_type_labels.go
+++ b/controllers/modelmesh/model_type_labels.go
@@ -47,9 +47,12 @@ func GetServingRuntimeSupportedModelTypeLabelSet(rt *api.ServingRuntime) StringS
 
 	// model type labels
 	for _, t := range rt.Spec.SupportedModelFormats {
-		set.Add("mt:" + t.Name)
-		if t.Version != nil {
-			set.Add("mt:" + t.Name + ":" + *t.Version)
+		// only include model type labels when autoSelect is true
+		if t.AutoSelect != nil && *t.AutoSelect {
+			set.Add("mt:" + t.Name)
+			if t.Version != nil {
+				set.Add("mt:" + t.Name + ":" + *t.Version)
+			}
 		}
 	}
 	// runtime label

--- a/controllers/modelmesh/model_type_labels_test.go
+++ b/controllers/modelmesh/model_type_labels_test.go
@@ -24,6 +24,7 @@ import (
 func TestGetServingRuntimeSupportedModelTypeLabelSet(t *testing.T) {
 	version_semver := "12345.312.2"
 	version_someString := "someString"
+	autoSelectVal := true
 	rt := api.ServingRuntime{
 		ObjectMeta: v1.ObjectMeta{
 			Name: "runtimename",
@@ -31,15 +32,18 @@ func TestGetServingRuntimeSupportedModelTypeLabelSet(t *testing.T) {
 		Spec: api.ServingRuntimeSpec{
 			SupportedModelFormats: []api.SupportedModelFormat{
 				{
-					Name: "type1",
+					Name:       "type1",
+					AutoSelect: &autoSelectVal,
 				},
 				{
-					Name:    "type2",
-					Version: &version_semver,
+					Name:       "type2",
+					Version:    &version_semver,
+					AutoSelect: &autoSelectVal,
 				},
 				{
-					Name:    "type2",
-					Version: &version_someString,
+					Name:       "type2",
+					Version:    &version_someString,
+					AutoSelect: &autoSelectVal,
 				},
 				{
 					Name: "type1",
@@ -53,7 +57,7 @@ func TestGetServingRuntimeSupportedModelTypeLabelSet(t *testing.T) {
 
 	expectedLabels := []string{
 		"mt:type1",
-		"mt:type3",
+		"mt:type2",
 		"mt:type2:" + version_semver,
 		"mt:type2:" + version_someString,
 		//runtime
@@ -61,6 +65,9 @@ func TestGetServingRuntimeSupportedModelTypeLabelSet(t *testing.T) {
 	}
 
 	labelSet := GetServingRuntimeSupportedModelTypeLabelSet(&rt)
+	if len(labelSet) != len(expectedLabels) {
+		t.Errorf("Length of set %v should be %d, but got %d", labelSet, len(expectedLabels), len(labelSet))
+	}
 	for _, e := range expectedLabels {
 		if !labelSet.Contains(e) {
 			t.Errorf("Missing expected entry [%s] in set: %v", e, labelSet)

--- a/controllers/testdata/test-servingruntime.yaml
+++ b/controllers/testdata/test-servingruntime.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   supportedModelFormats:
     - name: test
+      autoSelect: true
 
   multiModel: true
   grpcEndpoint: "port:8000"

--- a/docs/runtimes/custom_runtimes.md
+++ b/docs/runtimes/custom_runtimes.md
@@ -191,6 +191,7 @@ spec:
   supportedModelFormats:
     - name: new-modeltype
       version: "1"
+      autoSelect: true
   containers:
     - name: model-server
       image: samplemodelserver:latest
@@ -198,6 +199,9 @@ spec:
   grpcEndpoint: "port:8085"
   grpcDataEndpoint: "port:8090"
 ```
+
+In each entry of the `supportedModelFormats` list, `autoSelect: true` can optionally be specified to indicate that that the given `ServingRuntime` can be considered for automatic placement of `Predictors` or `InferenceServices` with the corresponding model type/format if no runtime is explicitly specified.
+For example, if a user applies a `Predictor` with `modelType.name: new-modeltype` and no `runtime` value, the above `ServingRuntime` will be used since it contains an "auto-selectable" supported model format that matches `new-modeltype`. If `autoSelect` were `false` or unspecified, the `Predictor` would fail to load with the message "No ServingRuntime supports specified model type" unless the runtime `example-runtime` was specified directly in the YAML.
 
 ### Runtime container resource allocations
 
@@ -266,6 +270,7 @@ spec:
   supportedModelFormats:
     - name: my_model_type # name of the model
       version: "1"
+      autoSelect: true
   containers:
     - args:
         - arg1

--- a/docs/runtimes/mlserver_custom.md
+++ b/docs/runtimes/mlserver_custom.md
@@ -133,6 +133,7 @@ metadata:
 spec:
   supportedModelFormats:
     - name: {{MODEL_TYPE}}
+      autoSelect: true
   builtInAdapter:
     memBufferBytes: 134217728
     modelLoadingTimeoutMillis: 90000

--- a/fvt/testdata/runtimes/non-mm-runtime.yaml
+++ b/fvt/testdata/runtimes/non-mm-runtime.yaml
@@ -19,6 +19,7 @@ spec:
   supportedModelFormats:
     - name: foo
       version: "1"
+      autoSelect: true
   containers:
     - name: kserve-container
       image: fo


### PR DESCRIPTION
## Motivation
In each supported model format of a ServingRuntime, a user can specify autoSelect as true to indicate that the given ServingRuntime can be used for automatic placement of a model of that format. Kserve uses this setting for automatic model placement decisions, but MM doesn't yet currently

## Modifications
Logic was added to have MM only consider SRs with model formats containing autoSelect as true when finding compatible runtimes.

The out-of-the-box ServingRuntimes now have "autoSelect: true" on all of their supported formats, so there is no behavior change for users.

## Results
MM respects the autoSelect field in each supported model format entry.

