### PR TITLE
Add script to setup user namespaces

### DIFF
--- a/docs/install/install-script.md
+++ b/docs/install/install-script.md
@@ -50,6 +50,8 @@ Run the script to install ModelMesh Serving CRDs, controller, and built-in runti
 
 A Kubernetes `--namespace` is required, which must already exist. You must also have cluster-admin authority and cluster access must be configured prior to running the install script.
 
+A list of Kubernetes namespaces `--user-namespaces` is optional to enable user namespaces for ModelMesh Serving. The script will skip the namespaces which don't already exist.
+
 The `--quickstart` option can be specified to install and configure supporting datastores in the same namespace (etcd and MinIO) for experimental/development use. If this is not chosen, the namespace provided must have an Etcd secret named `model-serving-etcd` created which provides access to the Etcd cluster. See the [instructions above](#setup-the-etcd-connection-information) on this step.
 
 ```shell
@@ -67,7 +69,11 @@ Flags:
   -n, --namespace                (required) Kubernetes namespace to deploy ModelMesh Serving to.
   -p, --install-config-path      Path to local model serve installation configs. Can be ModelMesh Serving tarfile or directory.
   -d, --delete                   Delete any existing instances of ModelMesh Serving in Kube namespace before running install, including CRDs, RBACs, controller, older CRD with serving.kserve.io api group name, etc.
+  -u, --user-namespaces          Kubernetes namespaces to enable for ModelMesh Serving
   --quickstart                   Install and configure required supporting datastores in the same namespace (etcd and MinIO) - for experimentation/development
+  --fvt                          Install and configure required supporting datastores in the same namespace (etcd and MinIO) - for development with fvt enabled
+  -dev, --dev-mode-logging       Enable dev mode logging (stacktraces on warning and no sampling)
+  --namespace-scope-mode         Run ModelMesh Serving in namespace scope mode
 
 Installs ModelMesh Serving CRDs, controller, and built-in runtimes into specified
 Kubernetes namespaces.
@@ -81,6 +87,39 @@ You can optionally provide a local `--install-config-path` that points to a loca
 You can also optionally use `--delete` to delete any existing instances of ModelMesh Serving in the designated Kube namespace before running the install.
 
 The installation will create a secret named `storage-config` if it does not already exist. If the `--quickstart` option was chosen, this will be populated with the connection details for the example models bucket in IBM Cloud Object Storage and the local MinIO; otherwise, it will be empty and ready for you to add your own entries.
+
+## Setup additional namespaces
+
+To enable additional namespaces for ModelMesh after the initial installation, you need to add a label named `modelmesh-enabled`, and optionally setup the storage secret `storage-config` and built-in runtimes, in the user namespaces.
+
+The following command will add the label to "your_namespace".
+
+```shell
+kubectl label namespace your_namespace modelmesh-enabled="true" --overwrite
+```
+
+You can also run a script to setup multiple user namespaces. See the setup help below for detail:
+
+```shell
+./scripts/setup_user_namespaces.sh --help
+Run this script to enable user namespaces for ModelMesh Serving, and optionally add the storage secret
+for example models and built-in serving runtimes to the target namespaces.
+
+usage: ./scripts/setup_user_namespaces.sh [flags]
+  Flags:
+    -u, --user-namespaces         (required) Kubernetes user namespaces to enable for ModelMesh
+    -c, --controller-namespace    Kubernetes ModelMesh controller namespace, default is modelmesh-serving
+    --create-storage-secret       Create storage secret for example models
+    --deploy-serving-runtimes     Deploy built-in serving runtimes
+    --dev-mode                    Run in development mode meaning the configs are local, not release based
+    -h, --help                    Display this help
+```
+
+The following command will setup two namespaces with the required label, optional storage secret, and built-in runtimes, so you can deploy sample predictors into any of them immediately.
+
+```shell
+./scripts/setup_user_namespaces.sh -u "ns1 ns2" --create-storage-secret --deploy-serving-runtimes
+```
 
 ## Delete the installation
 

--- a/scripts/setup_user_namespaces.sh
+++ b/scripts/setup_user_namespaces.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Copyright 2022 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.#
+
+USAGE="$(
+  cat <<EOF
+Run this script to enable user namespaces for ModelMesh Serving, and optionally add the storage secret
+for example models and built-in serving runtimes to the target namespaces.
+
+usage: $0 [flags]
+  Flags:
+    -u, --user-namespaces         (required) Kubernetes user namespaces to enable for ModelMesh
+    -c, --controller-namespace    Kubernetes ModelMesh controller namespace, default is modelmesh-serving
+    --create-storage-secret       Create storage secret for example models
+    --deploy-serving-runtimes     Deploy built-in serving runtimes
+    --dev-mode                    Run in development mode meaning the configs are local, not release based
+    -h, --help                    Display this help
+EOF
+)"
+
+ctrl_ns="modelmesh-serving"
+user_ns_array=()
+modelmesh_release="v0.8.0-rc0" # The latest release is the default
+create_storage_secret=false
+deploy_serving_runtimes=false
+dev_mode=false # When set to true, will use the locally cloned files instead of from a release
+
+while (($# > 0)); do
+  case "$1" in
+  -h | --help)
+   echo "$USAGE" >&2
+   exit 1
+    ;;
+  -c | --controller-namespace)
+    shift
+    ctrl_ns="$1"
+    ;;
+  -u | --user-namespaces)
+    shift
+    user_ns_array=($1)
+    ;;
+  --create-storage-secret)
+    create_storage_secret=true
+    ;;
+  --deploy-serving-runtimes)
+    deploy_serving_runtimes=true
+    ;;
+  --dev-mode)
+    dev_mode=true
+    ;;    
+  -*)
+    die "Unknown option: '${1}'"
+    ;;
+  esac
+  shift
+done
+
+if [[ ! -z $user_ns_array ]]; then
+  runtime_source="https://github.com/kserve/modelmesh-serving/releases/download/${modelmesh_release}/modelmesh-runtimes.yaml"
+  if [[ $dev_mode == "true" ]]; then
+    cp config/dependencies/minio-storage-secret.yaml . 
+    kustomize build config/runtimes --load-restrictor LoadRestrictionsNone > runtimes.yaml
+    runtime_source="runtimes.yaml"
+  else
+    wget https://raw.githubusercontent.com/kserve/modelmesh-serving/${modelmesh_release}/config/dependencies/minio-storage-secret.yaml
+  fi
+  sed -i.bak "s/controller_namespace/${ctrl_ns}/g" minio-storage-secret.yaml
+
+  for USER_NS in "${user_ns_array[@]}"; do
+    if ! kubectl get namespaces $USER_NS >/dev/null; then
+      echo "Kube namespace does not exist: $USER_NS. Will skip."
+    else
+      kubectl label namespace ${USER_NS} modelmesh-enabled="true" --overwrite
+      if [[ $create_storage_secret == "true" ]]; then
+        kubectl apply -f minio-storage-secret.yaml -n ${USER_NS}
+      fi
+      if [[ $deploy_serving_runtimes == "true" ]]; then
+        kubectl apply -f ${runtime_source} -n ${USER_NS}
+      fi
+    fi
+  done
+  rm minio-storage-secret.yaml
+  rm minio-storage-secret.yaml.bak
+  if [[ $dev_mode == "true" ]]; then
+    rm runtimes.yaml
+  fi
+else
+  echo "User namespaces are required, which can be specified as -u \"user1 user2\"."
+fi


### PR DESCRIPTION
Add a script file to setup additional user namespaces for modelmesh serving
controller to manage resources across multiple namespaces.

Signed-off-by: Chin Huang <chhuang@us.ibm.com>

#### Motivation
Provide script and instructions for users to enable additional namespaces for modelmesh serving.

#### Modifications
Add a script file to setup multiple user namespaces after initial installation
Update install doc with instructions

#### Result
The user can easily enable additional namespaces.