### PR TITLE
docs: Change install instructions to use release branch

### DIFF
--- a/docs/install/install-script.md
+++ b/docs/install/install-script.md
@@ -39,10 +39,11 @@ A secret named `model-serving-etcd` will be created and passed to the controller
 
 ## Installation
 
-Download and extract the latest modelmesh-serving from [GitHub](https://github.com/kserve/modelmesh-serving):
+Install the latest release of [modelmesh-serving](https://github.com/kserve/modelmesh-serving) by first cloning the corresponding release branch:
 
 ```shell
-git clone git@github.com:kserve/modelmesh-serving.git
+RELEASE=release-0.8
+git clone -b $RELEASE --depth 1 --single-branch git@github.com:kserve/modelmesh-serving.git
 cd modelmesh-serving
 ```
 

--- a/docs/install/install-script.md
+++ b/docs/install/install-script.md
@@ -43,7 +43,7 @@ Install the latest release of [modelmesh-serving](https://github.com/kserve/mode
 
 ```shell
 RELEASE=release-0.8
-git clone -b $RELEASE --depth 1 --single-branch git@github.com:kserve/modelmesh-serving.git
+git clone -b $RELEASE --depth 1 --single-branch https://github.com/kserve/modelmesh-serving.git
 cd modelmesh-serving
 ```
 


### PR DESCRIPTION
This will help to ensure that users coming to our installation documentation only use the latest stable release.
