### PR TITLE
feat: Allow installation using link to config archive

### DIFF
--- a/release/RELEASE_PROCESS.md
+++ b/release/RELEASE_PROCESS.md
@@ -35,6 +35,10 @@ It's generally a good idea to search the repo or control-f for strings of the ol
    - `kustomize build config/default > modelmesh.yaml`
    - `kustomize build config/runtimes --load-restrictor LoadRestrictionsNone > modelmesh-runtimes.yaml`
    - `cp config/dependencies/quickstart.yaml modelmesh-quickstart-dependencies.yaml`
+1. Generate config archive:
+   - Run one of the following depending on what version of `tar` you have. Be sure to replace the `update-me` below with the correct version:
+      - GNU tar: `RELEASE=update-me;tar -zcvf ${RELEASE}.tar.gz config/ --transform s/config/${RELEASE}/`
+      - BSD tar: `RELEASE=update-me;tar -zcvf ${RELEASE}.tar.gz  -s /config/${RELEASE}/ config/`
 1. Once everything has settled, tag and push the release with `git tag $VERSION` and `git push upstream $VERSION`. You can also tag the release in the GitHub UI.
    - The `modelmesh-controller` image will be published via GitHub Actions.
 1. Upload generated install manifests to GitHub release assets.

--- a/release/RELEASE_PROCESS.md
+++ b/release/RELEASE_PROCESS.md
@@ -37,8 +37,8 @@ It's generally a good idea to search the repo or control-f for strings of the ol
    - `cp config/dependencies/quickstart.yaml modelmesh-quickstart-dependencies.yaml`
 1. Generate config archive:
    - Run one of the following depending on what version of `tar` you have. Be sure to replace the `update-me` below with the correct version:
-      - GNU tar: `RELEASE=update-me;tar -zcvf ${RELEASE}.tar.gz config/ --transform s/config/${RELEASE}/`
-      - BSD tar: `RELEASE=update-me;tar -zcvf ${RELEASE}.tar.gz  -s /config/${RELEASE}/ config/`
+     - GNU tar: `RELEASE=update-me;tar -zcvf config-${RELEASE}.tar.gz config/ --transform s/config/config-${RELEASE}/`
+     - BSD tar: `RELEASE=update-me;tar -zcvf ${RELEASE}.tar.gz -s /config/${RELEASE}/ config/`
 1. Once everything has settled, tag and push the release with `git tag $VERSION` and `git push upstream $VERSION`. You can also tag the release in the GitHub UI.
    - The `modelmesh-controller` image will be published via GitHub Actions.
 1. Upload generated install manifests to GitHub release assets.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -32,7 +32,7 @@ function showHelp() {
   echo
   echo "Flags:"
   echo "  -n, --namespace                (required) Kubernetes namespace to deploy ModelMesh Serving to."
-  echo "  -p, --install-config-path      Path to local model serve installation configs. Can be ModelMesh Serving tarfile or directory."
+  echo "  -p, --install-config-path      Path to installation configs. Can be a local ModelMesh Serving config tarfile/directory or a URL to a config tarfile."
   echo "  -d, --delete                   Delete any existing instances of ModelMesh Serving in Kube namespace before running install, including CRDs, RBACs, controller, older CRD with serving.kserve.io api group name, etc."
   echo "  -u, --user-namespaces          Kubernetes namespaces to enable for ModelMesh Serving"
   echo "  --quickstart                   Install and configure required supporting datastores in the same namespace (etcd and MinIO) - for experimentation/development"
@@ -291,7 +291,7 @@ if [[ ! -z $user_ns_array ]]; then
   for user_ns in "${user_ns_array[@]}"; do
     if ! kubectl get namespaces $user_ns >/dev/null; then
       echo "Kube namespace does not exist: $user_ns. Will skip."
-    else 
+    else
       kubectl label namespace ${user_ns} modelmesh-enabled="true" --overwrite
       kubectl apply -f runtimes.yaml -n ${user_ns}
       if ([ $quickstart == "true" ] || [ $fvt == "true" ]); then


### PR DESCRIPTION
A user can now optionally pass in a link to an archive file of the configs using the `-p` option of the install.sh script.

This is more of a nice-to-have that allows some flexibility with installation options.
