### PR TITLE
docs: Miscellaneous minor doc fixes

### DIFF
--- a/docs/inferenceservice.md
+++ b/docs/inferenceservice.md
@@ -16,7 +16,7 @@ annotation, and will defer under the assumption that the ModelMesh controller wi
 
 ## Deploy an InferenceService
 
-First, Set your namespace context to `modelmesh-serving`.
+First, Set your namespace context to `modelmesh-serving` or whatever your modelmesh-enabled user namespace is.
 
 ```shell
 kubectl config set-context --current --namespace=modelmesh-serving
@@ -40,30 +40,6 @@ spec:
 EOF
 ```
 
-Or, if you deployed the latest KServe's
-[InferenceService interface](https://github.com/kserve/kserve/blob/master/config/crd/serving.kserve.io_inferenceservices.yaml)
-with the new storage interface. Try applying an SKLearn MNIST model with the latest storage Spec:
-
-```shell
-kubectl apply -f - <<EOF
-apiVersion: serving.kserve.io/v1beta1
-kind: InferenceService
-metadata:
-  name: example-sklearn-isvc
-  annotations:
-    serving.kserve.io/deploymentMode: ModelMesh
-spec:
-  predictor:
-    sklearn:
-      storage:
-        key: localMinIO
-        path: sklearn/mnist-svm.joblib
-        # schemaPath: null
-        parameters:
-          bucket: modelmesh-example-models
-EOF
-```
-
 Currently, only S3 based storage is supported. S3 credentials are expected to be stored in a secret called [`storage-config`](https://github.com/kserve/modelmesh-serving/blob/main/config/default/storage-secret.yaml). This means that the `storage-config` secret can contain a map of several keys that correspond to various credentials.
 
 In the InferenceService metadata, the annotation `serving.kserve.io/secretKey` is used as a placeholder for this needed secret key field.
@@ -73,7 +49,6 @@ Some other optional annotations that can be used are:
 - `serving.kserve.io/schemaPath`: The path within the object storage of a schema file. This allows specifying the input and output schema of ML models.
   - For example, if your model `storageURI` was `s3://modelmesh-example-models/pytorch/pytorch-cifar` the schema file would currently need to be in the
     same bucket (`modelmesh-example-models`). The path within this bucket is what would be specified in this annotation (e.g. `pytorch/schema/schema.json`)
-  - Instead of using annotations to specify the schemaPath parameter, the same parameter can be specified using the `schemaPath` value in the inference service storage spec.
 - `serving.kserve.io/servingRuntime`: A ServingRuntime name can be specified explicitly to have the InferenceService use that.
 
 You can find storage layout information for various model types [here](https://github.com/kserve/modelmesh-serving/tree/main/docs/model-types). This might come in handy when specifying a `storageUri` in the InferenceService.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -10,10 +10,11 @@ To quickly get started using ModelMesh Serving, here is a brief guide.
 
 ## 1. Install ModelMesh Serving
 
-### Clone the repository
+### Get the latest release
 
 ```shell
-git clone git@github.com:kserve/modelmesh-serving.git
+RELEASE=release-0.8
+git clone -b $RELEASE --depth 1 --single-branch https://github.com/kserve/modelmesh-serving.git
 cd modelmesh-serving
 ```
 

--- a/docs/runtimes/custom_runtimes.md
+++ b/docs/runtimes/custom_runtimes.md
@@ -226,7 +226,7 @@ Available attributes in the `ServingRuntime` spec:
 | Attribute                          | Description                                                                                                                                                               |
 | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `multiModel`                       | Whether this ServingRuntime is ModelMesh-compatible and intended for multi-model usage (as opposed to KServe single-model serving).                                       |
-| `disable`                          | Disables this runtime                                                                                                                                                     |
+| `disabled`                         | Disables this runtime                                                                                                                                                     |
 | `containers`                       | List of containers associated with the runtime                                                                                                                            |
 | `containers[ ].image`              | The container image for the current container                                                                                                                             |
 | `containers[ ].command`            | Executable command found in the provided image                                                                                                                            |

--- a/release/RELEASE_PROCESS.md
+++ b/release/RELEASE_PROCESS.md
@@ -29,8 +29,9 @@ It's generally a good idea to search the repo or control-f for strings of the ol
    - Edit `newTag` in `config/manager/kustomization.yaml`.
    - Edit the the `modelmesh`, `modelmesh-runtime-adapter`, and `rest-proxy` image tags in `config/default/config-defaults.yaml`.
    - Edit the `docs/component-versions.md` file with the version and component versions.
+   - Edit the `scripts/setup_user_namespaces.sh` file, changing the `modelmesh_release` version.
 1. Submit your PR to the release branch and wait for it to merge.
-1. Update `docs/component-versions.md` in the main branch with the same versions as above, then submit this as a PR to `main`. Wait for this to merge.
+1. Update `docs/component-versions.md` and `scripts/setup_user_namespaces.sh` in the main branch with the same versions as above, then submit this as a PR to `main`. Wait for this to merge.
 1. Generate release manifests:
    - `kustomize build config/default > modelmesh.yaml`
    - `kustomize build config/runtimes --load-restrictor LoadRestrictionsNone > modelmesh-runtimes.yaml`


### PR DESCRIPTION
- Updated quickstart to clone release branch
- Renamed disable to disabled which is the correct field name
- Added note about updating namespace prep script to release doc
- Removed misleading InferenceService storage spec docs as the new storage spec PR hasn't been merged yet. These can be re-added once the spec is actually updated.
