### PR TITLE
chore: Propagate GrpcMaxMessageSize to REST proxy

### DIFF
--- a/controllers/modelmesh/proxy.go
+++ b/controllers/modelmesh/proxy.go
@@ -21,9 +21,10 @@ import (
 )
 
 const (
-	restProxyPortEnvVar     = "REST_PROXY_LISTEN_PORT"
-	restProxyGrpcPortEnvVar = "REST_PROXY_GRPC_PORT"
-	restProxyTlsEnvVar      = "REST_PROXY_USE_TLS"
+	restProxyPortEnvVar           = "REST_PROXY_LISTEN_PORT"
+	restProxyGrpcMaxMsgSizeEnvVar = "REST_PROXY_GRPC_MAX_MSG_SIZE_BYTES"
+	restProxyGrpcPortEnvVar       = "REST_PROXY_GRPC_PORT"
+	restProxyTlsEnvVar            = "REST_PROXY_USE_TLS"
 )
 
 func (m *Deployment) addRESTProxyToDeployment(deployment *appsv1.Deployment) error {
@@ -42,6 +43,9 @@ func (m *Deployment) addRESTProxyToDeployment(deployment *appsv1.Deployment) err
 				}, {
 					Name:  restProxyTlsEnvVar,
 					Value: strconv.FormatBool(m.TLSSecretName != ""),
+				}, {
+					Name:  restProxyGrpcMaxMsgSizeEnvVar,
+					Value: strconv.Itoa(m.GrpcMaxMessageSize),
 				},
 			},
 			Ports: []corev1.ContainerPort{

--- a/controllers/testdata/servingruntime_controller.golden
+++ b/controllers/testdata/servingruntime_controller.golden
@@ -486,6 +486,8 @@ spec:
           value: "1234"
         - name: REST_PROXY_USE_TLS
           value: "false"
+        - name: REST_PROXY_GRPC_MAX_MSG_SIZE_BYTES
+          value: "16777216"
         image: kserve/rest-proxy:latest
         imagePullPolicy: Always
         name: rest-proxy


### PR DESCRIPTION
In order to keep the max gRPC message sizes aligned between ModelMesh and the REST-proxy, this PR takes the config value used by ModelMesh and passes it in to the REST-proxy as an env variable.

