### PR TITLE
Update permissions for namespaces/finalizers

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -41,6 +41,7 @@ rules:
       - ""
     resources:
       - namespaces
+      - namespaces/finalizers
     verbs:
       - get
       - list


### PR DESCRIPTION
This change was necessary for me to get the headless service to spin-up on OpenShift 4.9

#### To get modelmesh-serving working on OpenShift 4.9

#### Modifications:  update rbac to give permissions so the service can be created

#### Result:  The service comes up as expected on OpenShift 4.9
