### PR TITLE
Fix scripts for toolchain FVT

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -152,7 +152,7 @@ spec:
       - name: task-pvc
         workspace: pipeline-pvc
     - name: run-fvt
-      retries: 1
+      retries: 2
       taskRef:
         name: e2e-test
       runAfter:

--- a/scripts/deploy/iks/deploy-mm-serving.sh
+++ b/scripts/deploy/iks/deploy-mm-serving.sh
@@ -80,6 +80,9 @@ sed -i.bak 's/newTag:.*$/newTag: '"$GIT_COMMIT_SHORT"'/' config/manager/kustomiz
 sed -i.bak 's/newName:.*$/newName: '"$DOCKERSANDBOX_NAMESPACE\/modelmesh-controller"'/' config/manager/kustomization.yaml
 rm config/manager/kustomization.yaml.bak
 
+# Need to install InferenceService from kserve for fvt
+kubectl apply -f https://raw.githubusercontent.com/kserve/kserve/master/test/crds/serving.kserve.io_inferenceservices.yaml
+
 # Install and check if all pods are running - allow 60 retries (10 minutes)
 ./scripts/install.sh --namespace "$SERVING_NS" -u modelmesh-user --fvt
 wait_for_pods "$SERVING_NS" 60 "$SLEEP_TIME" || EXIT_CODE=$?

--- a/scripts/deploy/iks/undeploy-mm-serving.sh
+++ b/scripts/deploy/iks/undeploy-mm-serving.sh
@@ -47,4 +47,7 @@ mv kustomize /usr/local/bin/kustomize
 # Delete CRDs, controller, and built-in runtimes
 ./scripts/delete.sh --namespace "$SERVING_NS"
 
+# Also delete kserve InferenceService CRD
+kubectl delete -f https://raw.githubusercontent.com/kserve/kserve/master/test/crds/serving.kserve.io_inferenceservices.yaml || true
+
 echo "Finished modelmesh-serving undeployment." 


### PR DESCRIPTION
Fix scripts for toolchain FVT so the InferenceService CRD
from kserve will be installed and removed
Also increase FVT retry to 2

Signed-off-by: Chin Huang <chhuang@us.ibm.com>

#### Motivation

#### Modifications

#### Result
