### PR TITLE
chore: sync small internal changes

### DIFF
--- a/config/runtimes/mlserver-0.x.yaml
+++ b/config/runtimes/mlserver-0.x.yaml
@@ -55,7 +55,8 @@ spec:
         # Set server addr to localhost to ensure MLServer only listen inside the pod
         - name: MLSERVER_HOST
           value: "127.0.0.1"
-        # Increase gRPC max message size to 16 MiB to support larger payloads
+        # Increase gRPC max message size to support larger payloads
+        # Unlimited because it will be restricted at the model mesh layer
         - name: MLSERVER_GRPC_MAX_MESSAGE_LENGTH
           value: "-1"
       resources:

--- a/config/runtimes/mlserver-0.x.yaml
+++ b/config/runtimes/mlserver-0.x.yaml
@@ -57,7 +57,7 @@ spec:
           value: "127.0.0.1"
         # Increase gRPC max message size to 16 MiB to support larger payloads
         - name: MLSERVER_GRPC_MAX_MESSAGE_LENGTH
-          value: "16777216"
+          value: "-1"
       resources:
         requests:
           cpu: 500m

--- a/controllers/predictor_controller.go
+++ b/controllers/predictor_controller.go
@@ -526,8 +526,11 @@ func (pr *PredictorReconciler) updatePredictorStatusFromVModel(status *common.Pr
 	if mms := pr.MMServices.Get(name.Namespace); mms != nil {
 		endpoint, httpEndpoint = mms.InferenceEndpoints()
 	}
-	status.GrpcEndpoint = endpoint
-	status.HTTPEndpoint = httpEndpoint
+	if status.GrpcEndpoint != endpoint || status.HTTPEndpoint != httpEndpoint {
+		status.GrpcEndpoint = endpoint
+		status.HTTPEndpoint = httpEndpoint
+		changed = true
+	}
 
 	// This will be reinstated once the loading/loaded counts are added back to the Predictor CRD Status
 	//if counts != [3]int{status.LoadingCopies, status.LoadedCopies, status.FailedCopies} {

--- a/controllers/testdata/servingruntime_controller.golden
+++ b/controllers/testdata/servingruntime_controller.golden
@@ -157,7 +157,7 @@ spec:
         - name: MLSERVER_HOST
           value: 127.0.0.1
         - name: MLSERVER_GRPC_MAX_MESSAGE_LENGTH
-          value: "16777216"
+          value: "-1"
         image: mlserver-0:replace
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -404,7 +404,7 @@ spec:
         - name: MLSERVER_HOST
           value: 127.0.0.1
         - name: MLSERVER_GRPC_MAX_MESSAGE_LENGTH
-          value: "16777216"
+          value: "-1"
         image: mlserver-0:replace
         imagePullPolicy: IfNotPresent
         lifecycle:
@@ -676,7 +676,7 @@ spec:
         - name: MLSERVER_HOST
           value: 127.0.0.1
         - name: MLSERVER_GRPC_MAX_MESSAGE_LENGTH
-          value: "16777216"
+          value: "-1"
         image: mlserver-0:replace
         imagePullPolicy: IfNotPresent
         lifecycle:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -381,14 +381,9 @@ func NewMergedConfigFromString(configYaml string) (*Config, error) {
 	// Even if the default config has an image digest, a user should be able to
 	// override it with a tag (ignoring the default digest)
 	// HACK: There should be a better way to do this...
-	if v.GetString("storageHelperImage.tag") != defaultConfig.GetString("storageHelperImage.tag") &&
-		v.GetString("storageHelperImage.digest") == defaultConfig.GetString("storageHelperImage.digest") {
-		v.Set("storageHelperImage.digest", "")
-	}
-	if v.GetString("modelMeshImage.tag") != defaultConfig.GetString("modelMeshImage.tag") &&
-		v.GetString("modelMeshImage.digest") == defaultConfig.GetString("modelMeshImage.digest") {
-		v.Set("modelMeshImage.digest", "")
-	}
+	clearDigestIfTagsDiffer(v, "modelMeshImage")
+	clearDigestIfTagsDiffer(v, "storageHelperImage")
+	clearDigestIfTagsDiffer(v, "restProxy.image")
 
 	// unmarshal the config into a Config struct
 	var config Config
@@ -410,4 +405,11 @@ func NewMergedConfigFromString(configYaml string) (*Config, error) {
 	}
 
 	return &config, nil
+}
+
+func clearDigestIfTagsDiffer(v *viper.Viper, imageConfigField string) {
+	tag, digest := imageConfigField+".tag", imageConfigField+".digest"
+	if v.GetString(tag) != defaultConfig.GetString(tag) && v.GetString(digest) == defaultConfig.GetString(digest) {
+		v.Set(digest, "")
+	}
 }

--- a/pkg/mmesh/modelmesh_service.go
+++ b/pkg/mmesh/modelmesh_service.go
@@ -100,7 +100,6 @@ func (mms *MMService) UpdateConfig(cp *config.ConfigProvider) (*config.Config, b
 	if restPort != mms.restPort {
 		mms.restPort = restPort
 		specChange = true
-		clientChange = true
 	}
 	endpoint := cfg.ModelMeshEndpoint
 	if endpoint == "" {


### PR DESCRIPTION
#### Motivation

In an effort to rebase our internal wml-serving repo on the kserve/modelmesh-serving repo, we are syncing some of the differences internally externally. All of the below changes already exist internally.

#### Modifications

- Set MLServer GRPC message size to unlimited
   - This is because the MLServer GRPC message size is already limited by the `MM_SVC_GRPC_MAX_MSG_SIZE`. This allows us to only have to worry about one variable that limits the message size.
-  Refactor checking digest runtime images to see if they match the provided digest into a separate method
- Remove clientChange for rest port, do not need to reconnect to mmesh client if rest port changes
- Set changed flag if endpoints change in predictor reconciler
   - In the predictor reconciler, we should update the Predictor Status if/when just the resolved endpoints change. This in theory could happen independently of other things changing since it's tied to the service lifecycle.
   - Make sure to set the changed flag in the updatePredictorStatusFromVModel function if either http or grpc endpoint has change.
   - Copied changes from [internal commit](https://github.ibm.com/ai-foundation/wml-serving/commit/c5806427bb3c02f38a329d7a8e2eced66eb060ea)

#### Result

Cleaner code that aligns with internal version.

Signed-off-by: Anh-Uong <anh.uong@ibm.com>