### PR TITLE
Add performance test to e2e toolchain

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -173,9 +173,24 @@ spec:
       workspaces:
       - name: task-pvc
         workspace: pipeline-pvc
-    - name: undeploy
+    - name: run-perf-test
       runAfter:
         - run-fvt
+      taskRef:
+        name: run-perf-test
+      params:
+        - name: kubernetes-cluster
+          value: $(params.kubernetes-cluster)
+        - name: apikey
+          value: $(params.apikey)
+        - name: serving-ns
+          value: $(params.serving-ns)
+      workspaces:
+      - name: task-pvc
+        workspace: pipeline-pvc
+    - name: undeploy
+      runAfter:
+        - run-perf-test
       taskRef:
         name: undeploy
       params:

--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -329,6 +329,43 @@ spec:
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
+  name: run-perf-test
+spec:
+  params:
+    - name: apikey
+      description: the ibmcloud api key
+    - name: serving-ns
+      description: kubeflow namespace
+      default: kubeflow
+    - name: archive-dir
+      description: archive directory
+      default: "."
+    - name: kubernetes-cluster
+      description: cluster name
+  workspaces:
+  - name: task-pvc
+    mountPath: /artifacts
+  steps:
+    - name: run-performance-test
+      image: docker.io/aipipeline/pipeline-base-image:1.2
+      env:
+        - name: SERVING_KUBERNETES_CLUSTER_NAME
+          value: $(params.kubernetes-cluster)
+        - name: IBM_CLOUD_API_KEY
+          value: $(params.apikey)
+        - name: ARCHIVE_DIR
+          value: $(params.archive-dir)
+        - name: SERVING_NS
+          value: $(params.serving-ns)
+      command: ["/bin/bash", "-c"]
+      args:
+        - set -ex;
+          cd /artifacts && source build.properties;
+          source ./scripts/deploy/iks/run-perf-test.sh;
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
   name: undeploy
 spec:
   params:

--- a/scripts/deploy/iks/run-perf-test.sh
+++ b/scripts/deploy/iks/run-perf-test.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Need the following env var
+# - SERVING_KUBERNETES_CLUSTER_NAME:   kube cluster name
+# - SERVING_NS:                        namespace for modelmesh-serving, defulat: modelmesh-serving
+
+# These env vars should come from the pipeline run environment properties
+echo "SERVING_KUBERNETES_CLUSTER_NAME=$SERVING_KUBERNETES_CLUSTER_NAME"
+echo "SERVING_NS=$SERVING_NS"
+
+retry() {
+  local max=$1; shift
+  local interval=$1; shift
+
+  until "$@"; do
+    echo "trying.."
+    max=$((max-1))
+    if [[ "$max" -eq 0 ]]; then
+      return 1
+    fi
+    sleep "$interval"
+  done
+}
+
+retry 3 3 ibmcloud login --apikey "${IBM_CLOUD_API_KEY}" --no-region
+retry 3 3 ibmcloud target -r "$REGION" -o "$ORG" -s "$SPACE" -g "$RESOURCE_GROUP"
+retry 3 3 ibmcloud ks cluster config -c "$SERVING_KUBERNETES_CLUSTER_NAME"
+
+kubectl config set-context --current --namespace=${SERVING_NS}
+
+# Use the perofrmance test yaml in modelmesh-performance repo to ensure no performance degradation
+kubectl apply -f https://github.com/kserve/modelmesh-performance/raw/main/perf_test/k8s/howitzer_k6_test-k8s.yaml
+succeeded=0
+failed=0
+check_interval=3
+
+while [[ $succeeded -eq 0 && $failed -eq 0 ]]
+do 
+  succeeded=$(kubectl describe job.batch/perf-test-job | grep "Pods Statuses" | tr -s ' '  | cut -d ' ' -f 6)
+  failed=$(kubectl describe job.batch/perf-test-job | grep "Pods Statuses" | tr -s ' '  | cut -d ' ' -f 9)
+  if [[ $succeeded -gt 0 ]];
+  then
+    echo "Performance verification passed!"
+    podname=$(kubectl get po | grep perf-test-job | tr -s ' '  | cut -d ' ' -f 1)
+    kubectl logs $podname
+    exit 0
+  else
+    if [[ $failed -gt 0 ]];
+    then
+      echo "Performance verification failed..."
+      podname=$(kubectl get po | grep perf-test-job | tr -s ' '  | cut -d ' ' -f 1)
+      kubectl logs $podname
+      exit 1
+    else
+      echo "Still running, check in $check_interval seconds..."
+      sleep $check_interval
+    fi
+  fi
+done


### PR DESCRIPTION
Add performance test to e2e toolchain

Signed-off-by: Chin Huang <chhuang@us.ibm.com>

#### Motivation
Make sure the performance is not degraded

#### Modifications
Add a step to the end to end toolchain that runs every night to run performance tests, developed under [modelmesh-performance](https://github.com/kserve/modelmesh-performance) repo.

#### Result
Performance tests will be run nightly and the step will fail if performance is worse than the threshold.
