### PR TITLE
feat: Add TotalCopies in Predictor Status spec

### DIFF
--- a/apis/serving/common/common_types.go
+++ b/apis/serving/common/common_types.go
@@ -137,11 +137,11 @@ type PredictorStatus struct {
 	// +optional
 	GrpcEndpoint string `json:"grpcEndpoint"`
 
-	//TODO TBC whether or not these are exposed here
+	// Total number copies of this predictor's models that are currently loaded
+	// +kubebuilder:default=0
+	TotalCopies int `json:"totalCopies"`
 
-	//	// How many copies of this predictor's models are currently loaded - NOT YET SUPPORTED
-	//	// +kubebuilder:default=0
-	//	LoadedCopies int `json:"loadedCopies"`
+	//TODO TBC whether or not this is exposed here
 	//	// How many copies of this predictor's models are currently loading - NOT YET SUPPORTED
 	//	// +kubebuilder:default=0
 	//	LoadingCopies int `json:"loadingCopies"`

--- a/apis/serving/common/common_types.go
+++ b/apis/serving/common/common_types.go
@@ -145,7 +145,7 @@ type PredictorStatus struct {
 	//	// +kubebuilder:default=0
 	//	LoadingCopies int `json:"loadingCopies"`
 
-	// Total number copies of this predictor's models
+	// Total number of copies of this predictor's models
 	// +kubebuilder:default=0
 	TotalCopies int `json:"totalCopies"`
 

--- a/apis/serving/common/common_types.go
+++ b/apis/serving/common/common_types.go
@@ -137,14 +137,17 @@ type PredictorStatus struct {
 	// +optional
 	GrpcEndpoint string `json:"grpcEndpoint"`
 
-	// Total number copies of this predictor's models that are currently loaded
-	// +kubebuilder:default=0
-	TotalCopies int `json:"totalCopies"`
-
-	//TODO TBC whether or not this is exposed here
+	//TODO TBC whether or not these are exposed here
+	//	// How many copies of this predictor's models are currently loaded - NOT YET SUPPORTED
+	//	// +kubebuilder:default=0
+	//	LoadedCopies int `json:"loadedCopies"`
 	//	// How many copies of this predictor's models are currently loading - NOT YET SUPPORTED
 	//	// +kubebuilder:default=0
 	//	LoadingCopies int `json:"loadingCopies"`
+
+	// Total number copies of this predictor's models
+	// +kubebuilder:default=0
+	TotalCopies int `json:"totalCopies"`
 
 	// How many copies of this predictor's models failed to load recently
 	// +kubebuilder:default=0

--- a/apis/serving/v1alpha1/predictor_types.go
+++ b/apis/serving/v1alpha1/predictor_types.go
@@ -126,7 +126,7 @@ type Predictor struct {
 
 	// Add these to the default below once reinstated: {loadedCopies:0, loadingCopies:0}
 
-	// +kubebuilder:default={transitionStatus:UpToDate, activeModelState:Pending, targetModelState:"", available:false, failedCopies:0}
+	// +kubebuilder:default={transitionStatus:UpToDate, activeModelState:Pending, targetModelState:"", available:false, failedCopies:0, loadedCopies:0}
 	Status common.PredictorStatus `json:"status,omitempty"`
 }
 

--- a/apis/serving/v1alpha1/predictor_types.go
+++ b/apis/serving/v1alpha1/predictor_types.go
@@ -126,7 +126,7 @@ type Predictor struct {
 
 	// Add these to the default below once reinstated: {loadedCopies:0, loadingCopies:0}
 
-	// +kubebuilder:default={transitionStatus:UpToDate, activeModelState:Pending, targetModelState:"", available:false, failedCopies:0, loadedCopies:0}
+	// +kubebuilder:default={transitionStatus:UpToDate, activeModelState:Pending, targetModelState:"", available:false, failedCopies:0, totalCopies:0}
 	Status common.PredictorStatus `json:"status,omitempty"`
 }
 

--- a/config/crd/bases/serving.kserve.io_predictors.yaml
+++ b/config/crd/bases/serving.kserve.io_predictors.yaml
@@ -151,8 +151,8 @@ spec:
                 activeModelState: Pending
                 available: false
                 failedCopies: 0
-                loadedCopies: 0
                 targetModelState: ""
+                totalCopies: 0
                 transitionStatus: UpToDate
               description: PredictorStatus defines the observed state of Predictor
               properties:

--- a/config/crd/bases/serving.kserve.io_predictors.yaml
+++ b/config/crd/bases/serving.kserve.io_predictors.yaml
@@ -151,6 +151,7 @@ spec:
                 activeModelState: Pending
                 available: false
                 failedCopies: 0
+                loadedCopies: 0
                 targetModelState: ""
                 transitionStatus: UpToDate
               description: PredictorStatus defines the observed state of Predictor
@@ -225,6 +226,12 @@ spec:
                     - Loaded
                     - FailedToLoad
                   type: string
+                totalCopies:
+                  default: 0
+                  description:
+                    Total number copies of this predictor's models that are
+                    currently loaded
+                  type: integer
                 transitionStatus:
                   default: UpToDate
                   description:
@@ -241,6 +248,7 @@ spec:
                 - available
                 - failedCopies
                 - targetModelState
+                - totalCopies
                 - transitionStatus
               type: object
           type: object

--- a/config/crd/bases/serving.kserve.io_predictors.yaml
+++ b/config/crd/bases/serving.kserve.io_predictors.yaml
@@ -228,9 +228,7 @@ spec:
                   type: string
                 totalCopies:
                   default: 0
-                  description:
-                    Total number copies of this predictor's models that are
-                    currently loaded
+                  description: Total number copies of this predictor's models
                   type: integer
                 transitionStatus:
                   default: UpToDate

--- a/controllers/predictor_controller.go
+++ b/controllers/predictor_controller.go
@@ -433,7 +433,7 @@ func (pr *PredictorReconciler) updatePredictorStatusFromVModel(status *common.Pr
 	}
 
 	tmsBefore := status.TargetModelState
-	counts := [3]int{}
+	counts := [4]int{}
 	if amfr == "" || amfr == common.ModelLoadFailed {
 		countModelCopyStates(vModelState.ActiveModelStatus, &counts)
 	}
@@ -533,17 +533,13 @@ func (pr *PredictorReconciler) updatePredictorStatusFromVModel(status *common.Pr
 	}
 
 	// This will be reinstated once the loading/loaded counts are added back to the Predictor CRD Status
-	//if counts != [3]int{status.LoadingCopies, status.LoadedCopies, status.FailedCopies} {
-	//	status.LoadingCopies, status.LoadedCopies, status.FailedCopies = counts[0], counts[1], counts[2]
+	//if counts != [4]int{status.LoadingCopies, status.LoadedCopies, status.FailedCopies, status.TotalCopies} {
+	//	status.LoadingCopies, status.LoadedCopies, status.FailedCopies, status.TotalCopies = counts[0], counts[1], counts[2], counts[3]
 	//	changed = true
 	//}
-	if counts[1] != status.TotalCopies {
-		status.TotalCopies = counts[1]
-		changed = true
-	}
 
-	if counts[2] != status.FailedCopies {
-		status.FailedCopies = counts[2]
+	if counts[2] != status.FailedCopies || counts[3] != status.TotalCopies {
+		status.FailedCopies, status.TotalCopies = counts[2], counts[3]
 		changed = true
 	}
 
@@ -559,7 +555,7 @@ func setStatusFailureInfo(crStatus *common.PredictorStatus, info *common.Failure
 	return true
 }
 
-func countModelCopyStates(statusInfo *mmeshapi.ModelStatusInfo, counts *[3]int) {
+func countModelCopyStates(statusInfo *mmeshapi.ModelStatusInfo, counts *[4]int) {
 	if statusInfo == nil {
 		return
 	}
@@ -573,6 +569,7 @@ func countModelCopyStates(statusInfo *mmeshapi.ModelStatusInfo, counts *[3]int) 
 			case mmeshapi.ModelStatusInfo_LOADING_FAILED:
 				counts[2] += 1
 			}
+			counts[3] += 1
 		}
 	}
 }

--- a/controllers/predictor_controller.go
+++ b/controllers/predictor_controller.go
@@ -537,6 +537,10 @@ func (pr *PredictorReconciler) updatePredictorStatusFromVModel(status *common.Pr
 	//	status.LoadingCopies, status.LoadedCopies, status.FailedCopies = counts[0], counts[1], counts[2]
 	//	changed = true
 	//}
+	if counts[1] != status.TotalCopies {
+		status.TotalCopies = counts[1]
+		changed = true
+	}
 
 	if counts[2] != status.FailedCopies {
 		status.FailedCopies = counts[2]

--- a/pkg/predictor_source/inferenceservice_registry.go
+++ b/pkg/predictor_source/inferenceservice_registry.go
@@ -253,6 +253,7 @@ func (isvcr InferenceServiceRegistry) Get(ctx context.Context, nname types.Names
 	p.Status.TransitionStatus = common.TransitionStatus(inferenceService.Status.ModelStatus.TransitionStatus)
 	if inferenceService.Status.ModelStatus.ModelCopies != nil {
 		p.Status.FailedCopies = inferenceService.Status.ModelStatus.ModelCopies.FailedCopies
+		p.Status.TotalCopies = inferenceService.Status.ModelStatus.ModelCopies.TotalCopies
 	}
 	if inferenceService.Status.ModelStatus.ModelRevisionStates != nil {
 		p.Status.ActiveModelState = common.ModelState(inferenceService.Status.ModelStatus.ModelRevisionStates.ActiveModelState)
@@ -325,6 +326,7 @@ func (isvcr InferenceServiceRegistry) UpdateStatus(ctx context.Context, predicto
 	}
 	inferenceService.Status.ModelStatus.ModelCopies = &v1beta1.ModelCopies{
 		FailedCopies: predictor.Status.FailedCopies,
+		TotalCopies:  predictor.Status.TotalCopies,
 	}
 	if predictor.Status.LastFailureInfo != nil {
 		inferenceService.Status.ModelStatus.LastFailureInfo = &v1beta1.FailureInfo{


### PR DESCRIPTION
**Motivation** 

`TotalCopies` is a recently added field to the InferenceService status which tracks the number
of copies/replicas of the model. We should start using it.

**Modifications**

`TotalCopies` was added to the `PredictorStatus`, and the Predictor CRD was regenerated.
The InferenceService registry now propagates this field.

**Result**

`TotalCopies` is now available in the `Predictor` and `InferenceService` statuses. 