### PR TITLE
chore: Add missing kubebuilder annotation

### DIFF
--- a/controllers/service_controller.go
+++ b/controllers/service_controller.go
@@ -119,7 +119,7 @@ func (r *ServiceReconciler) getMMService(namespace string,
 }
 
 // +kubebuilder:rbac:groups="",resources=services;services/finalizers,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups="",resources=namespaces;namespaces/finalizers,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups="monitoring.coreos.com",resources=servicemonitors,verbs=get;list;watch;create;update;patch;delete
 
 func (r *ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
A kubebuilder RBAC annotation was added to correspond to an addition in PR #130
for "namespaces/finalizers".