### PR TITLE
feat: support env overrides for the adapter

### DIFF
--- a/controllers/modelmesh/runtime.go
+++ b/controllers/modelmesh/runtime.go
@@ -246,17 +246,15 @@ func (m *Deployment) addRuntimeToDeployment(deployment *appsv1.Deployment) error
 			})
 		}
 
-		if len(rt.Spec.BuiltInAdapter.Env) > 0 {
-		outer:
-			for oidx := range rt.Spec.BuiltInAdapter.Env {
-				for eidx := range builtInAdapterContainer.Env {
-					if builtInAdapterContainer.Env[eidx].Name == rt.Spec.BuiltInAdapter.Env[oidx].Name {
-						builtInAdapterContainer.Env[eidx] = rt.Spec.BuiltInAdapter.Env[oidx]
-						continue outer
-					}
+	outer:
+		for oidx := range rt.Spec.BuiltInAdapter.Env {
+			for eidx := range builtInAdapterContainer.Env {
+				if builtInAdapterContainer.Env[eidx].Name == rt.Spec.BuiltInAdapter.Env[oidx].Name {
+					builtInAdapterContainer.Env[eidx] = rt.Spec.BuiltInAdapter.Env[oidx]
+					continue outer
 				}
-				builtInAdapterContainer.Env = append(builtInAdapterContainer.Env, rt.Spec.BuiltInAdapter.Env[oidx])
 			}
+			builtInAdapterContainer.Env = append(builtInAdapterContainer.Env, rt.Spec.BuiltInAdapter.Env[oidx])
 		}
 		deployment.Spec.Template.Spec.Containers = append(deployment.Spec.Template.Spec.Containers, builtInAdapterContainer)
 	}

--- a/controllers/modelmesh/runtime.go
+++ b/controllers/modelmesh/runtime.go
@@ -187,9 +187,7 @@ func (m *Deployment) addRuntimeToDeployment(deployment *appsv1.Deployment) error
 
 		// the puller and adapter containers are the same image and are given the
 		// same resources
-		if m.PullerResources != nil {
-			builtInAdapterContainer.Resources = *m.PullerResources
-		}
+		builtInAdapterContainer.Resources = *m.PullerResources
 
 		builtInAdapterContainer.VolumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      ConfigStorageMount,
@@ -197,7 +195,7 @@ func (m *Deployment) addRuntimeToDeployment(deployment *appsv1.Deployment) error
 			ReadOnly:  true,
 		})
 
-		defaultEnvVars := []corev1.EnvVar{
+		builtInAdapterContainer.Env = []corev1.EnvVar{
 			{
 				Name:  "ADAPTER_PORT",
 				Value: "8085",
@@ -231,13 +229,8 @@ func (m *Deployment) addRuntimeToDeployment(deployment *appsv1.Deployment) error
 				Name:  "RUNTIME_VERSION",
 				Value: runtimeVersion,
 			},
-		}
-
-		// To avoid reallocation, count the maximum number of env vars there could be
-		numVarsDefault := len(defaultEnvVars) // count of default env vars
-		numVarsOptional := 2                  // count of envs that may be added from annotations below
-		builtInAdapterContainer.Env = make([]corev1.EnvVar, numVarsDefault, numVarsDefault+numVarsOptional+len(rt.Spec.BuiltInAdapter.Env))
-		copy(builtInAdapterContainer.Env, defaultEnvVars)
+			{}, {}, {}, {}, // allocate larger array to avoid reallocation
+		}[:7]
 
 		if mlc, ok := rt.Annotations["maxLoadingConcurrency"]; ok {
 			builtInAdapterContainer.Env = append(builtInAdapterContainer.Env, corev1.EnvVar{

--- a/controllers/modelmesh/runtime_test.go
+++ b/controllers/modelmesh/runtime_test.go
@@ -29,6 +29,17 @@ import (
 	api "github.com/kserve/modelmesh-serving/apis/serving/v1alpha1"
 )
 
+func newMockModelMeshDeployment(t *testing.T, rt *api.ServingRuntime) *Deployment {
+	return &Deployment{
+		Owner: rt,
+		Log:   testr.New(t),
+
+		PullerResources: &v1.ResourceRequirements{},
+		// may need to add more as tests expand
+	}
+
+}
+
 func TestOverlayMockRuntime(t *testing.T) {
 	const adapterEnvOverrideName = "ADAPTER_PORT"
 	const adapterEnvOverrideValue = "override"
@@ -40,10 +51,10 @@ func TestOverlayMockRuntime(t *testing.T) {
 			ServingRuntimePodSpec: api.ServingRuntimePodSpec{
 				Containers: []v1.Container{
 					{
-						Name:            "my-runtime",
+						Name:            adapterType,
 						Image:           "image",
 						ImagePullPolicy: "IfNotPresent",
-						WorkingDir:      "my-working-dir",
+						WorkingDir:      "mock-working-dir",
 						Env: []corev1.EnvVar{
 							{
 								Name:  "simple",
@@ -95,7 +106,7 @@ func TestOverlayMockRuntime(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name: adapterType,
+							Name: "mm",
 						},
 					},
 				},
@@ -103,7 +114,7 @@ func TestOverlayMockRuntime(t *testing.T) {
 		},
 	}
 
-	m := Deployment{Owner: v, Log: testr.New(t)}
+	m := newMockModelMeshDeployment(t, v)
 	m.addRuntimeToDeployment(deployment)
 
 	scontainer := v.Spec.Containers[0]


### PR DESCRIPTION
#### Motivation

We are working to align CRDs between this repo and kserve/kserve. In https://github.com/kserve/modelmesh-serving/pull/148, we mirrored updates to the ServingRuntime CRDs. This PR implements use of BuiltInAdapter.Env.

#### Modifications

- allow values in BuiltInAdapter.Env to override environment variables added by the controller
