### PR TITLE
feat: implement additions to the runtime pod spec

### DIFF
--- a/controllers/modelmesh/const.go
+++ b/controllers/modelmesh/const.go
@@ -14,8 +14,8 @@
 package modelmesh
 
 const (
-	ModelMeshContainer = "mm"
-	RESTProxyContainer = "rest-proxy"
+	ModelMeshContainerName = "mm"
+	RESTProxyContainerName = "rest-proxy"
 
 	GrpcPortEnvVar         = "INTERNAL_GRPC_PORT"
 	ServeGrpcPortEnvVar    = "INTERNAL_SERVING_GRPC_PORT"
@@ -31,7 +31,7 @@ const (
 	ConfigStorageMount = "storage-config"
 
 	//The name of the puller container
-	PullerContainer = "puller"
+	PullerContainerName = "puller"
 
 	//The env variable puller uses to configure it's own listen port
 	PullerEnvListenPort = "PORT"

--- a/controllers/modelmesh/const.go
+++ b/controllers/modelmesh/const.go
@@ -22,6 +22,12 @@ const (
 	GrpcUdsPathEnvVar      = "INTERNAL_GRPC_SOCKET_PATH"
 	ServeGrpcUdsPathEnvVar = "INTERNAL_SERVING_GRPC_SOCKET_PATH"
 
+	EtcdSecretKey = "etcd_connection"
+	EtcdVolume    = "etcd-config"
+
+	ModelsDirVolume = "models-dir"
+	SocketVolume    = "domain-socket"
+
 	ConfigStorageMount = "storage-config"
 
 	//The name of the puller container

--- a/controllers/modelmesh/constraints.go
+++ b/controllers/modelmesh/constraints.go
@@ -30,7 +30,7 @@ const (
 func (m *Deployment) addModelTypeConstraints(deployment *appsv1.Deployment) error {
 	rt := m.Owner
 	var container *corev1.Container
-	if _, container = findContainer(ModelMeshContainer, deployment); container == nil {
+	if _, container = findContainer(ModelMeshContainerName, deployment); container == nil {
 		return errors.New("unable to find the model mesh container")
 	}
 

--- a/controllers/modelmesh/etcd.go
+++ b/controllers/modelmesh/etcd.go
@@ -28,7 +28,7 @@ func (m *Deployment) configureMMDeploymentForEtcdSecret(deployment *appsv1.Deplo
 	EtcdSecretName := m.EtcdSecretName
 
 	for containerI, container := range deployment.Spec.Template.Spec.Containers {
-		if container.Name == ModelMeshContainer {
+		if container.Name == ModelMeshContainerName {
 			for i, env := range container.Env {
 				if env.Name == kvStoreEnvVar {
 					env.Value = "etcd:" + etcdMountPath + "/" + EtcdSecretKey

--- a/controllers/modelmesh/etcd.go
+++ b/controllers/modelmesh/etcd.go
@@ -19,8 +19,6 @@ import (
 )
 
 const (
-	EtcdSecretKey = "etcd_connection" //TODO probably move this const
-	etcdVolume    = "etcd-config"
 	etcdMountPath = "/opt/kserve/mmesh/etcd"
 	kvStoreEnvVar = "KV_STORE"
 )
@@ -40,7 +38,7 @@ func (m *Deployment) configureMMDeploymentForEtcdSecret(deployment *appsv1.Deplo
 
 			volumeMountExists := false
 			for i := range container.VolumeMounts {
-				if container.VolumeMounts[i].Name == etcdVolume {
+				if container.VolumeMounts[i].Name == EtcdVolume {
 					volumeMountExists = true
 					container.VolumeMounts[i].ReadOnly = true
 					container.VolumeMounts[i].MountPath = etcdMountPath
@@ -48,7 +46,7 @@ func (m *Deployment) configureMMDeploymentForEtcdSecret(deployment *appsv1.Deplo
 			}
 			if !volumeMountExists {
 				container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
-					Name:      etcdVolume,
+					Name:      EtcdVolume,
 					ReadOnly:  true,
 					MountPath: etcdMountPath,
 				})
@@ -60,7 +58,7 @@ func (m *Deployment) configureMMDeploymentForEtcdSecret(deployment *appsv1.Deplo
 
 	volumeExists := false
 	for _, volume := range deployment.Spec.Template.Spec.Volumes {
-		if volume.Name == etcdVolume {
+		if volume.Name == EtcdVolume {
 			volumeExists = true
 			volume.Secret = &corev1.SecretVolumeSource{
 				SecretName: EtcdSecretName,
@@ -69,7 +67,7 @@ func (m *Deployment) configureMMDeploymentForEtcdSecret(deployment *appsv1.Deplo
 	}
 	if !volumeExists {
 		deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, corev1.Volume{
-			Name: etcdVolume,
+			Name: EtcdVolume,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName: EtcdSecretName,

--- a/controllers/modelmesh/modelmesh.go
+++ b/controllers/modelmesh/modelmesh.go
@@ -169,8 +169,8 @@ func (m *Deployment) transform(deployment *appsv1.Deployment, funcs ...func(depl
 
 func (m *Deployment) addMMDomainSocketMount(deployment *appsv1.Deployment) error {
 	var c *corev1.Container
-	if _, c = findContainer(ModelMeshContainer, deployment); c == nil {
-		return fmt.Errorf("Could not find the model mesh container %v", ModelMeshContainer)
+	if _, c = findContainer(ModelMeshContainerName, deployment); c == nil {
+		return fmt.Errorf("Could not find the model mesh container %v", ModelMeshContainerName)
 	}
 
 	if hasUnix, mountPoint, err := mountPoint(m.Owner); err != nil {
@@ -189,7 +189,7 @@ func (m *Deployment) addMMEnvVars(deployment *appsv1.Deployment) error {
 	// start with the "additional" env vars so that they are overwritten by
 	// the values set below
 	for _, envvar := range m.ModelMeshAdditionalEnvVars {
-		if err := setEnvironmentVar(ModelMeshContainer, envvar.Name, envvar.Value, deployment); err != nil {
+		if err := setEnvironmentVar(ModelMeshContainerName, envvar.Name, envvar.Value, deployment); err != nil {
 			return err
 		}
 	}
@@ -201,18 +201,18 @@ func (m *Deployment) addMMEnvVars(deployment *appsv1.Deployment) error {
 			return err
 		}
 		if tcpE, ok := e.(TCPEndpoint); ok {
-			if err = setEnvironmentVar(ModelMeshContainer, ServeGrpcPortEnvVar, tcpE.Port, deployment); err != nil {
+			if err = setEnvironmentVar(ModelMeshContainerName, ServeGrpcPortEnvVar, tcpE.Port, deployment); err != nil {
 				return err
 			}
 		} else if udsE, ok := e.(UnixEndpoint); ok {
-			if err = setEnvironmentVar(ModelMeshContainer, ServeGrpcUdsPathEnvVar, udsE.Path, deployment); err != nil {
+			if err = setEnvironmentVar(ModelMeshContainerName, ServeGrpcUdsPathEnvVar, udsE.Path, deployment); err != nil {
 				return err
 			}
 		}
 	}
 
 	if useStorageHelper(rt) {
-		if err := setEnvironmentVar(ModelMeshContainer, GrpcPortEnvVar, strconv.Itoa(PullerPortNumber), deployment); err != nil {
+		if err := setEnvironmentVar(ModelMeshContainerName, GrpcPortEnvVar, strconv.Itoa(PullerPortNumber), deployment); err != nil {
 			return err
 		}
 	} else {
@@ -221,11 +221,11 @@ func (m *Deployment) addMMEnvVars(deployment *appsv1.Deployment) error {
 			return err
 		}
 		if tcpE, ok := e.(TCPEndpoint); ok {
-			if err = setEnvironmentVar(ModelMeshContainer, GrpcPortEnvVar, tcpE.Port, deployment); err != nil {
+			if err = setEnvironmentVar(ModelMeshContainerName, GrpcPortEnvVar, tcpE.Port, deployment); err != nil {
 				return err
 			}
 		} else if udsE, ok := e.(UnixEndpoint); ok {
-			if err = setEnvironmentVar(ModelMeshContainer, GrpcUdsPathEnvVar, udsE.Path, deployment); err != nil {
+			if err = setEnvironmentVar(ModelMeshContainerName, GrpcUdsPathEnvVar, udsE.Path, deployment); err != nil {
 				return err
 			}
 		}
@@ -233,24 +233,24 @@ func (m *Deployment) addMMEnvVars(deployment *appsv1.Deployment) error {
 
 	if m.EnableAccessLogging {
 		//See https://github.com/kserve/modelmesh/blob/main/src/main/java/com/ibm/watson/modelmesh/ModelMeshEnvVars.java#L52
-		if err := setEnvironmentVar(ModelMeshContainer, "MM_LOG_EACH_INVOKE", "true", deployment); err != nil {
+		if err := setEnvironmentVar(ModelMeshContainerName, "MM_LOG_EACH_INVOKE", "true", deployment); err != nil {
 			return err
 		}
 	}
 
 	if m.GrpcMaxMessageSize > 0 {
 		//See https://github.com/kserve/modelmesh/blob/main/src/main/java/com/ibm/watson/modelmesh/ModelMeshEnvVars.java#L38
-		if err := setEnvironmentVar(ModelMeshContainer, "MM_SVC_GRPC_MAX_MSG_SIZE", strconv.Itoa(m.GrpcMaxMessageSize), deployment); err != nil {
+		if err := setEnvironmentVar(ModelMeshContainerName, "MM_SVC_GRPC_MAX_MSG_SIZE", strconv.Itoa(m.GrpcMaxMessageSize), deployment); err != nil {
 			return err
 		}
 	}
 
 	// See https://github.com/kserve/modelmesh/blob/main/src/main/java/com/ibm/watson/modelmesh/ModelMeshEnvVars.java#L31
-	if err := setEnvironmentVar(ModelMeshContainer, "MM_KVSTORE_PREFIX", ModelMeshEtcdPrefix, deployment); err != nil {
+	if err := setEnvironmentVar(ModelMeshContainerName, "MM_KVSTORE_PREFIX", ModelMeshEtcdPrefix, deployment); err != nil {
 		return err
 	}
 	// See https://github.com/kserve/modelmesh/blob/main/src/main/java/com/ibm/watson/modelmesh/ModelMeshEnvVars.java#L65
-	if err := setEnvironmentVar(ModelMeshContainer, "MM_DEFAULT_VMODEL_OWNER", m.DefaultVModelOwner, deployment); err != nil {
+	if err := setEnvironmentVar(ModelMeshContainerName, "MM_DEFAULT_VMODEL_OWNER", m.DefaultVModelOwner, deployment); err != nil {
 		return err
 	}
 

--- a/controllers/modelmesh/modelmesh.go
+++ b/controllers/modelmesh/modelmesh.go
@@ -111,7 +111,6 @@ func (m *Deployment) Apply(ctx context.Context) error {
 
 			if tErr := m.transform(deployment,
 				m.addVolumesToDeployment,
-				m.addStorageConfigVolume,
 				m.addMMDomainSocketMount,
 				m.addPassThroughPodFieldsToDeployment,
 				m.addRuntimeToDeployment,

--- a/controllers/modelmesh/proxy.go
+++ b/controllers/modelmesh/proxy.go
@@ -32,7 +32,7 @@ func (m *Deployment) addRESTProxyToDeployment(deployment *appsv1.Deployment) err
 	if m.RESTProxyEnabled {
 		cspec := corev1.Container{
 			Image: m.RESTProxyImage,
-			Name:  RESTProxyContainer,
+			Name:  RESTProxyContainerName,
 			Env: []corev1.EnvVar{
 				{
 					Name:  restProxyPortEnvVar,

--- a/controllers/modelmesh/puller.go
+++ b/controllers/modelmesh/puller.go
@@ -81,7 +81,7 @@ func addPullerSidecar(rt *api.ServingRuntime, deployment *appsv1.Deployment, pul
 		Resources: *pullerResources,
 		VolumeMounts: []corev1.VolumeMount{
 			{
-				Name:      modelsDirVolume,
+				Name:      ModelsDirVolume,
 				MountPath: PullerModelPath,
 			},
 			{

--- a/controllers/modelmesh/puller.go
+++ b/controllers/modelmesh/puller.go
@@ -70,7 +70,7 @@ func addPullerSidecar(rt *api.ServingRuntime, deployment *appsv1.Deployment, pul
 			},
 		},
 		Image:   pullerImage,
-		Name:    PullerContainer,
+		Name:    PullerContainerName,
 		Command: pullerImageCommand,
 		Ports: []corev1.ContainerPort{
 			{

--- a/controllers/modelmesh/runtime.go
+++ b/controllers/modelmesh/runtime.go
@@ -26,10 +26,8 @@ import (
 )
 
 const (
-	modelsDirVolume string  = "models-dir"
-	socketVolume    string  = "domain-socket"
-	ModelsDir       string  = "/models"
-	ModelDirScale   float64 = 1.5
+	ModelsDir     string  = "/models"
+	ModelDirScale float64 = 1.5
 )
 
 //Sets the model mesh grace period to match the deployment grace period
@@ -38,7 +36,7 @@ func (m *Deployment) syncGracePeriod(deployment *appsv1.Deployment) error {
 		gracePeriodS := deployment.Spec.Template.Spec.TerminationGracePeriodSeconds
 		gracePeriodMs := *gracePeriodS * int64(1000)
 		gracePeriodMsStr := strconv.FormatInt(gracePeriodMs, 10)
-		err := setEnvironmentVar("mm", "SHUTDOWN_TIMEOUT_MS", gracePeriodMsStr, deployment)
+		err := setEnvironmentVar(ModelMeshContainer, "SHUTDOWN_TIMEOUT_MS", gracePeriodMsStr, deployment)
 		return err
 	}
 
@@ -53,7 +51,7 @@ func (m *Deployment) addVolumesToDeployment(deployment *appsv1.Deployment) error
 	volumes := rt.Spec.Volumes
 
 	volumes = append(volumes, corev1.Volume{
-		Name: modelsDirVolume,
+		Name: ModelsDirVolume,
 		VolumeSource: corev1.VolumeSource{
 			EmptyDir: &corev1.EmptyDirVolumeSource{Medium: "", SizeLimit: modelsDirSize},
 		},
@@ -61,7 +59,7 @@ func (m *Deployment) addVolumesToDeployment(deployment *appsv1.Deployment) error
 
 	if hasUnixSockets, _, _ := unixDomainSockets(rt); hasUnixSockets {
 		volumes = append(volumes, corev1.Volume{
-			Name: socketVolume,
+			Name: SocketVolume,
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
@@ -120,7 +118,7 @@ func (m *Deployment) addRuntimeToDeployment(deployment *appsv1.Deployment) error
 
 	volumeMounts := []corev1.VolumeMount{
 		{
-			Name:      modelsDirVolume,
+			Name:      ModelsDirVolume,
 			MountPath: ModelsDir,
 		},
 	}
@@ -269,7 +267,7 @@ func addDomainSocketMount(rt *api.ServingRuntime, c *corev1.Container) error {
 	}
 	if requiresDomainSocketMounting {
 		c.VolumeMounts = append(c.VolumeMounts, corev1.VolumeMount{
-			Name:      socketVolume,
+			Name:      SocketVolume,
 			MountPath: domainSocketMountPoint,
 		})
 	}

--- a/controllers/modelmesh/runtime.go
+++ b/controllers/modelmesh/runtime.go
@@ -67,14 +67,7 @@ func (m *Deployment) addVolumesToDeployment(deployment *appsv1.Deployment) error
 		})
 	}
 
-	deployment.Spec.Template.Spec.Volumes = volumes
-
-	return nil
-}
-
-func (m *Deployment) addStorageConfigVolume(deployment *appsv1.Deployment) error {
-	rt := m.Owner
-	// need to mount storage volume for built-in adapters and the scenarios where StorageHelper is not disabled/specified.
+	// need to mount storage volume for built-in adapters and the scenarios where StorageHelper is not disabled
 	if rt.Spec.BuiltInAdapter != nil || useStorageHelper(rt) {
 		storageVolume := corev1.Volume{
 			Name: ConfigStorageMount,
@@ -85,8 +78,10 @@ func (m *Deployment) addStorageConfigVolume(deployment *appsv1.Deployment) error
 			},
 		}
 
-		deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, storageVolume)
+		volumes = append(volumes, storageVolume)
 	}
+
+	deployment.Spec.Template.Spec.Volumes = volumes
 
 	return nil
 }

--- a/controllers/modelmesh/runtime.go
+++ b/controllers/modelmesh/runtime.go
@@ -36,7 +36,7 @@ func (m *Deployment) syncGracePeriod(deployment *appsv1.Deployment) error {
 		gracePeriodS := deployment.Spec.Template.Spec.TerminationGracePeriodSeconds
 		gracePeriodMs := *gracePeriodS * int64(1000)
 		gracePeriodMsStr := strconv.FormatInt(gracePeriodMs, 10)
-		err := setEnvironmentVar(ModelMeshContainer, "SHUTDOWN_TIMEOUT_MS", gracePeriodMsStr, deployment)
+		err := setEnvironmentVar(ModelMeshContainerName, "SHUTDOWN_TIMEOUT_MS", gracePeriodMsStr, deployment)
 		return err
 	}
 

--- a/controllers/modelmesh/runtime.go
+++ b/controllers/modelmesh/runtime.go
@@ -125,6 +125,10 @@ func (m *Deployment) addRuntimeToDeployment(deployment *appsv1.Deployment) error
 
 	// Now add the containers specified in serving runtime spec
 	for i := range rt.Spec.Containers {
+		// by modifying in-place we rely on the fact that the cacheing
+		// client in controller-runtime deep copies objects it retrieves
+		// by default, this would be a problem if that was disabled
+		// REF: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/cache
 		cspec := &rt.Spec.Containers[i]
 
 		// defaults

--- a/controllers/modelmesh/runtime_test.go
+++ b/controllers/modelmesh/runtime_test.go
@@ -176,12 +176,8 @@ func TestAddVolumesToDeployment(t *testing.T) {
 
 			// map of expected volume names to bool of whether or not it is found
 			expectedVolumes := map[string]bool{
-<<<<<<< HEAD
-				modelsDirVolume: false,
-=======
 				// models dir is always mounted
 				ModelsDirVolume: false,
->>>>>>> 3f2b16e (fixup: volume  support)
 			}
 			for _, v := range tt.expectedExtraVolumes {
 				expectedVolumes[v] = false
@@ -190,7 +186,7 @@ func TestAddVolumesToDeployment(t *testing.T) {
 				expectedVolumes[ConfigStorageMount] = false
 			}
 			if tt.expectSocketVolume {
-				expectedVolumes[socketVolume] = false
+				expectedVolumes[SocketVolume] = false
 			}
 
 			for _, v := range deployment.Spec.Template.Spec.Volumes {

--- a/controllers/modelmesh/tls.go
+++ b/controllers/modelmesh/tls.go
@@ -63,7 +63,7 @@ func (m *Deployment) configureMMDeploymentForTLSSecret(deployment *appsv1.Deploy
 	podSpec := &deployment.Spec.Template.Spec
 	for ci := range podSpec.Containers {
 		container := &podSpec.Containers[ci]
-		if container.Name == ModelMeshContainer || (m.RESTProxyEnabled && container.Name == RESTProxyContainer) {
+		if container.Name == ModelMeshContainerName || (m.RESTProxyEnabled && container.Name == RESTProxyContainerName) {
 			container.Env = append(container.Env, corev1.EnvVar{
 				Name: tlsCertEnvVar, Value: tlsSecretMountPath + "/" + TLSSecretCertKey,
 			})

--- a/controllers/servingruntime_controller.go
+++ b/controllers/servingruntime_controller.go
@@ -250,22 +250,6 @@ func (r *ServingRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	return ctrl.Result{RequeueAfter: requeueDuration}, nil
 }
 
-func validateServingRuntimeSpec(rt *api.ServingRuntime) error {
-	if rt.Spec.BuiltInAdapter == nil {
-		return nil // nothing to check
-	}
-	st := rt.Spec.BuiltInAdapter.ServerType
-	if _, ok := builtInServerTypes[st]; !ok {
-		return fmt.Errorf("unrecognized built-in runtime server type %s", st)
-	}
-	for _, c := range rt.Spec.Containers {
-		if c.Name == string(st) {
-			return nil // found, all good
-		}
-	}
-	return fmt.Errorf("must include runtime Container with name %s", st)
-}
-
 func (r *ServingRuntimeReconciler) determineReplicasAndRequeueDuration(ctx context.Context, log logr.Logger,
 	config *config.Config, rt *api.ServingRuntime) (uint16, time.Duration, error) {
 

--- a/controllers/servingruntime_validator.go
+++ b/controllers/servingruntime_validator.go
@@ -127,8 +127,8 @@ func checkName(name string, internalNames map[string]interface{}, logStr string)
 		return fmt.Errorf("%s %s is reserved for internal use", logStr, name)
 	}
 
-	if strings.HasPrefix(name, "mm") || strings.HasPrefix(name, "kserve") {
-		return fmt.Errorf("%s cannot start with \"mm\" or \"kserve\", which are reserved for internal use", logStr)
+	if strings.HasPrefix(name, "mm-") {
+		return fmt.Errorf("%s cannot start with \"mm-\", which is reserved for internal use", logStr)
 	}
 	return nil
 }

--- a/controllers/servingruntime_validator.go
+++ b/controllers/servingruntime_validator.go
@@ -99,13 +99,9 @@ func validateContainer(c *corev1.Container) error {
 	}
 
 	// Check for overlapping port declarations
-	// TODO: just Reserve 8000-8999 for internal use?
 	for _, p := range c.Ports {
-		// 8080 is used for LiteLinks communication in Model Mesh
-		// 8089 is used for Model Mesh probes
-		// 8085 is the port the built-in adapter listens on
-		if p.ContainerPort == 8080 || p.ContainerPort == 8089 || p.ContainerPort == 8085 {
-			return errors.New("Ports 8080 and 8089 are reserved for internal use")
+		if internal, ok := internalPorts[p.ContainerPort]; ok {
+			return fmt.Errorf("Port %d is reserved for internal use", internal)
 		}
 	}
 
@@ -145,6 +141,13 @@ var internalOnlyVolumeMounts = map[string]interface{}{
 	modelmesh.EtcdVolume:            nil,
 	modelmesh.InternalConfigMapName: nil,
 	modelmesh.SocketVolume:          nil,
+}
+
+var internalPorts = map[int32]interface{}{
+	8080: nil, // is used for LiteLinks communication in Model Mesh
+	8085: nil, // is the port the built-in adapter listens on
+	8089: nil, // is used for Model Mesh probes
+	8090: nil, // is used for default preStop hooks
 }
 
 var internalVolumes = map[string]interface{}{

--- a/controllers/servingruntime_validator.go
+++ b/controllers/servingruntime_validator.go
@@ -118,8 +118,8 @@ func validateVolumes(rt *api.ServingRuntime) error {
 }
 
 func checkName(name string, internalNames map[string]interface{}, logStr string) error {
-	if internal, ok := internalNames[name]; ok {
-		return fmt.Errorf("%s %s is reserved for internal use", logStr, internal)
+	if _, ok := internalNames[name]; ok {
+		return fmt.Errorf("%s %s is reserved for internal use", logStr, name)
 	}
 
 	if strings.HasPrefix(name, "mm") || strings.HasPrefix(name, "kserve") {

--- a/controllers/servingruntime_validator.go
+++ b/controllers/servingruntime_validator.go
@@ -1,0 +1,154 @@
+// Copyright 2021 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package controllers
+
+import (
+	"fmt"
+	"strings"
+
+	"errors"
+
+	corev1 "k8s.io/api/core/v1"
+
+	api "github.com/kserve/modelmesh-serving/apis/serving/v1alpha1"
+	"github.com/kserve/modelmesh-serving/controllers/modelmesh"
+)
+
+// validateServingRuntimeSpec returns an error if the spec is invalid
+// Checks include:
+// - BuiltInAdapter has a container matching the name of the type
+// - names of entries do not overlap with reserved names
+// - spec does not override required internals like Volumes or Containers
+// - containers do not mount internal only Volumes
+// - some fields in containers are controlled by model mesh and cannot be set
+// - check for overlaps in declared ports with internal ports
+func validateServingRuntimeSpec(rt *api.ServingRuntime) error {
+	return validationChain(rt,
+		validateBuiltInAdapterSpec,
+		validateContainers,
+		validateVolumes,
+	)
+}
+
+func validationChain(rt *api.ServingRuntime, funcs ...func(*api.ServingRuntime) error) error {
+	for _, f := range funcs {
+		if err := f(rt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateBuiltInAdapterSpec(rt *api.ServingRuntime) error {
+	if rt.Spec.BuiltInAdapter == nil {
+		return nil // nothing to check
+	}
+
+	st := rt.Spec.BuiltInAdapter.ServerType
+	if _, ok := builtInServerTypes[st]; !ok {
+		return fmt.Errorf("unrecognized built-in runtime server type %s", st)
+	}
+	for ic := range rt.Spec.Containers {
+		if rt.Spec.Containers[ic].Name == string(st) {
+			return nil // found, all good
+		}
+	}
+
+	return fmt.Errorf("must include runtime container with name %s", st)
+}
+
+func validateContainers(rt *api.ServingRuntime) error {
+	for i := range rt.Spec.Containers {
+		c := &rt.Spec.Containers[i]
+		if err := validateContainer(c); err != nil {
+			return fmt.Errorf("container spec for %s is invalid: %w", c.Name, err)
+		}
+	}
+	return nil
+}
+
+func validateContainer(c *corev1.Container) error {
+	// Block container names that conflict with injected containers or reserved prefixes
+	internalContainerNames := []string{
+		modelmesh.ModelMeshContainer,
+		modelmesh.RESTProxyContainer,
+		modelmesh.PullerContainer,
+	}
+	if err := checkName(c.Name, internalContainerNames, "container name"); err != nil {
+		return err
+	}
+
+	// TODO: block if container name matches `*-adapter`??
+
+	// Block fields required for model-mesh to control the pod lifecycle
+	if c.ReadinessProbe != nil || c.Lifecycle != nil {
+		return errors.New("ReadinessProbe and Lifecycle are managed by modelmesh and cannot be set")
+	}
+
+	// Block volume mounts for private internal volumes
+	internalOnlyVolumeMounts := []string{
+		modelmesh.ConfigStorageMount,
+		modelmesh.EtcdVolume,
+		modelmesh.InternalConfigMapName,
+		modelmesh.SocketVolume,
+	}
+	for vmi := range c.VolumeMounts {
+		if err := checkName(c.VolumeMounts[vmi].Name, internalOnlyVolumeMounts, "volume"); err != nil {
+			return err
+		}
+	}
+
+	// Check for overlapping port declarations
+	// TODO: just Reserve 8000-8999 for internal use?
+	for _, p := range c.Ports {
+		// 8080 is used for LiteLinks communication in Model Mesh
+		// 8089 is used for Model Mesh probes
+		// 8085 is the port the built-in adapter listens on
+		if p.ContainerPort == 8080 || p.ContainerPort == 8089 || p.ContainerPort == 8085 {
+			return errors.New("Ports 8080 and 8089 are reserved for internal use")
+		}
+	}
+
+	return nil
+}
+
+func validateVolumes(rt *api.ServingRuntime) error {
+	internalVolumes := []string{
+		modelmesh.ConfigStorageMount,
+		modelmesh.EtcdVolume,
+		modelmesh.InternalConfigMapName,
+		modelmesh.SocketVolume,
+		modelmesh.ModelsDirVolume,
+	}
+	for vi := range rt.Spec.Volumes {
+		if err := checkName(rt.Spec.Volumes[vi].Name, internalVolumes, "volume"); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func checkName(name string, internalNames []string, logStr string) error {
+	for _, in := range internalNames {
+		if name == in {
+			return fmt.Errorf("%s %s is reserved for internal use", logStr, in)
+		}
+	}
+
+	if strings.HasPrefix(name, "mm") || strings.HasPrefix(name, "kserve") {
+		return fmt.Errorf("%s cannot start with \"mm\" or \"kserve\", which are reserved for internal use", logStr)
+	}
+	return nil
+}

--- a/controllers/servingruntime_validator.go
+++ b/controllers/servingruntime_validator.go
@@ -29,8 +29,8 @@ import (
 // Checks include:
 // - BuiltInAdapter has a container matching the name of the type
 // - names of entries do not overlap with reserved names
-// - spec does not override required internals like Volumes or Containers
-// - containers do not mount internal only Volumes
+// - spec does not override required internals like volumes or containers
+// - containers do not mount internal only volumes
 // - some fields in containers are controlled by model mesh and cannot be set
 // - check for overlaps in declared ports with internal ports
 func validateServingRuntimeSpec(rt *api.ServingRuntime) error {
@@ -83,8 +83,6 @@ func validateContainer(c *corev1.Container) error {
 	if err := checkName(c.Name, internalContainerNames, "container name"); err != nil {
 		return err
 	}
-
-	// TODO: block if container name matches `*-adapter`??
 
 	// Block fields required for model-mesh to control the pod lifecycle
 	if c.ReadinessProbe != nil || c.Lifecycle != nil {

--- a/controllers/servingruntime_validator.go
+++ b/controllers/servingruntime_validator.go
@@ -81,9 +81,9 @@ func validateContainers(rt *api.ServingRuntime) error {
 func validateContainer(c *corev1.Container) error {
 	// Block container names that conflict with injected containers or reserved prefixes
 	internalContainerNames := []string{
-		modelmesh.ModelMeshContainer,
-		modelmesh.RESTProxyContainer,
-		modelmesh.PullerContainer,
+		modelmesh.ModelMeshContainerName,
+		modelmesh.RESTProxyContainerName,
+		modelmesh.PullerContainerName,
 	}
 	if err := checkName(c.Name, internalContainerNames, "container name"); err != nil {
 		return err

--- a/controllers/servingruntime_validator.go
+++ b/controllers/servingruntime_validator.go
@@ -106,6 +106,11 @@ func validateContainer(c *corev1.Container) error {
 		if internal, ok := internalPorts[p.ContainerPort]; ok {
 			return fmt.Errorf("Port %d is reserved for internal use", internal)
 		}
+		// Reserve a range for future use
+		// ascii 'm' is 109. ModelMesh -> mm -> m*m = 11881
+		if p.ContainerPort >= 11881 && p.ContainerPort < 11900 {
+			return fmt.Errorf("Port range [11881-11899] is reserved for internal use")
+		}
 	}
 
 	return nil

--- a/controllers/servingruntime_validator_test.go
+++ b/controllers/servingruntime_validator_test.go
@@ -108,7 +108,7 @@ func TestValidateServingRuntimeSpec(t *testing.T) {
 					ServingRuntimePodSpec: api.ServingRuntimePodSpec{
 						Containers: []v1.Container{
 							{
-								Name: "kserve-arbitrary",
+								Name: "mm-arbitrary",
 							},
 						},
 					},
@@ -258,7 +258,7 @@ func TestValidateServingRuntimeSpec(t *testing.T) {
 								Name: "bad-container",
 								VolumeMounts: []v1.VolumeMount{
 									{
-										Name: "kserve-internal",
+										Name: "mm-arbitrary",
 									},
 								},
 							},

--- a/controllers/servingruntime_validator_test.go
+++ b/controllers/servingruntime_validator_test.go
@@ -152,6 +152,54 @@ func TestValidateServingRuntimeSpec(t *testing.T) {
 			expectError: true,
 		},
 		{
+			name: "block conflicting port name",
+			servingRuntime: &api.ServingRuntime{
+				Spec: api.ServingRuntimeSpec{
+					ServingRuntimePodSpec: api.ServingRuntimePodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "some-container",
+							},
+							{
+								Name: "bad-container",
+								Ports: []v1.ContainerPort{
+									{
+										Name:          "grpc",
+										ContainerPort: 32768,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "block reserved port name",
+			servingRuntime: &api.ServingRuntime{
+				Spec: api.ServingRuntimeSpec{
+					ServingRuntimePodSpec: api.ServingRuntimePodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "some-container",
+							},
+							{
+								Name: "bad-container",
+								Ports: []v1.ContainerPort{
+									{
+										Name:          "mm-arbitrary",
+										ContainerPort: 32768,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
 			name: "block conflicting port",
 			servingRuntime: &api.ServingRuntime{
 				Spec: api.ServingRuntimeSpec{

--- a/controllers/servingruntime_validator_test.go
+++ b/controllers/servingruntime_validator_test.go
@@ -1,0 +1,255 @@
+// Copyright 2021 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package controllers
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+
+	api "github.com/kserve/modelmesh-serving/apis/serving/v1alpha1"
+	"github.com/kserve/modelmesh-serving/controllers/modelmesh"
+)
+
+func TestValidateServingRuntimeSpec(t *testing.T) {
+	for _, tt := range []struct {
+		name           string
+		servingRuntime *api.ServingRuntime
+		expectError    bool
+	}{
+		{
+			name: "valid serving runtime",
+			servingRuntime: &api.ServingRuntime{
+				Spec: api.ServingRuntimeSpec{
+					ServingRuntimePodSpec: api.ServingRuntimePodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "arbitrary-name",
+								SecurityContext: &v1.SecurityContext{
+									Capabilities: &v1.Capabilities{
+										Add: []v1.Capability{"ALL"},
+									},
+								},
+								Ports: []v1.ContainerPort{
+									{
+										Name:          "my-port",
+										ContainerPort: 54321,
+									},
+								},
+								VolumeMounts: []v1.VolumeMount{
+									{
+										Name: "my-volume",
+									},
+								},
+							},
+						},
+						Volumes: []v1.Volume{
+							{
+								Name: "my-volume",
+							},
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "valid serving runtime with adapter",
+			servingRuntime: &api.ServingRuntime{
+				Spec: api.ServingRuntimeSpec{
+					ServingRuntimePodSpec: api.ServingRuntimePodSpec{
+						Containers: []v1.Container{
+							// A container matching the name of the adapter ServerType must exist
+							{
+								Name: string(api.MLServer),
+							},
+						},
+					},
+					BuiltInAdapter: &api.BuiltInAdapter{
+						ServerType: api.MLServer,
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "block container name model mesh",
+			servingRuntime: &api.ServingRuntime{
+				Spec: api.ServingRuntimeSpec{
+					ServingRuntimePodSpec: api.ServingRuntimePodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "some-container",
+							},
+							{
+								Name: modelmesh.ModelMeshContainer,
+							},
+						},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "block container name reserved",
+			servingRuntime: &api.ServingRuntime{
+				Spec: api.ServingRuntimeSpec{
+					ServingRuntimePodSpec: api.ServingRuntimePodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "kserve-arbitrary",
+							},
+						},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "block container lifecycle",
+			servingRuntime: &api.ServingRuntime{
+				Spec: api.ServingRuntimeSpec{
+					ServingRuntimePodSpec: api.ServingRuntimePodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "some-container",
+							},
+							{
+								Name:      "bad-container",
+								Lifecycle: &v1.Lifecycle{},
+							},
+						},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "block container readiness probe",
+			servingRuntime: &api.ServingRuntime{
+				Spec: api.ServingRuntimeSpec{
+					ServingRuntimePodSpec: api.ServingRuntimePodSpec{
+						Containers: []v1.Container{
+							{
+								Name:           "bad-container",
+								ReadinessProbe: &v1.Probe{},
+							},
+						},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "block conflicting port",
+			servingRuntime: &api.ServingRuntime{
+				Spec: api.ServingRuntimeSpec{
+					ServingRuntimePodSpec: api.ServingRuntimePodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "some-container",
+							},
+							{
+								Name: "bad-container",
+								Ports: []v1.ContainerPort{
+									{
+										ContainerPort: 8080,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "block mount of internal volume",
+			servingRuntime: &api.ServingRuntime{
+				Spec: api.ServingRuntimeSpec{
+					ServingRuntimePodSpec: api.ServingRuntimePodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "some-container",
+							},
+							{
+								Name: "bad-container",
+								VolumeMounts: []v1.VolumeMount{
+									{
+										Name: modelmesh.InternalConfigMapName,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "block mount of reserved volume name",
+			servingRuntime: &api.ServingRuntime{
+				Spec: api.ServingRuntimeSpec{
+					ServingRuntimePodSpec: api.ServingRuntimePodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "some-container",
+							},
+							{
+								Name: "bad-container",
+								VolumeMounts: []v1.VolumeMount{
+									{
+										Name: "kserve-internal",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "block BuiltInAdapter missing runtime container",
+			servingRuntime: &api.ServingRuntime{
+				Spec: api.ServingRuntimeSpec{
+					ServingRuntimePodSpec: api.ServingRuntimePodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "some-container",
+							},
+						},
+					},
+					BuiltInAdapter: &api.BuiltInAdapter{
+						ServerType: api.MLServer,
+					},
+				},
+			},
+			expectError: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateServingRuntimeSpec(tt.servingRuntime)
+
+			if tt.expectError && err == nil {
+				t.Errorf("Expected an error, but didn't get one")
+
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+		})
+	}
+
+}

--- a/controllers/servingruntime_validator_test.go
+++ b/controllers/servingruntime_validator_test.go
@@ -223,6 +223,29 @@ func TestValidateServingRuntimeSpec(t *testing.T) {
 			expectError: true,
 		},
 		{
+			name: "block reserved port",
+			servingRuntime: &api.ServingRuntime{
+				Spec: api.ServingRuntimeSpec{
+					ServingRuntimePodSpec: api.ServingRuntimePodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "some-container",
+							},
+							{
+								Name: "bad-container",
+								Ports: []v1.ContainerPort{
+									{
+										ContainerPort: 11888,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
 			name: "block mount of internal volume",
 			servingRuntime: &api.ServingRuntime{
 				Spec: api.ServingRuntimeSpec{

--- a/controllers/servingruntime_validator_test.go
+++ b/controllers/servingruntime_validator_test.go
@@ -93,7 +93,7 @@ func TestValidateServingRuntimeSpec(t *testing.T) {
 								Name: "some-container",
 							},
 							{
-								Name: modelmesh.ModelMeshContainer,
+								Name: modelmesh.ModelMeshContainerName,
 							},
 						},
 					},


### PR DESCRIPTION
#### Motivation

We are working to align CRDs between this repo and kserve/kserve. In https://github.com/kserve/modelmesh-serving/pull/148, we mirrored updates to the ServingRuntime CRDs. This PR provides implementations related to the changes to the Pod spec included in the runtime: allowing additional Volumes to be specified, using the full `v1.Container` spec.

These additions allow more freedom in how a Runtime Deployment can be configured, but this also opens up more potential for conflicts with the containers injected by the controller. For this reason, this PR also adds some constraints and validation on ServingRuntimes, but attempts to mostly keep the current behavior.

#### Modifications

- small refactors to gather and expose variables with names for internal Volumes
- use full `v1.Container` from the CRD when generating a runtime Deployment
- add validation of the runtime container specs now that they are more flexible
  - block conflicts with internal entities and unintended uses
- reserve `mm-` as a prefix for names of containers, volumes, and ports in the runtime for future use
- if containers declare ports, check them against internal port usage to avoid conflicts (also reserve ports 11881-11899 for potential future use)

#### Result
