### PR TITLE
chore: update quickstart/fvt etcd image tag

### DIFF
--- a/config/dependencies/fvt.yaml
+++ b/config/dependencies/fvt.yaml
@@ -38,7 +38,7 @@ spec:
         - http://0.0.0.0:2379
         - --advertise-client-urls
         - http://0.0.0.0:2379
-      image: quay.io/coreos/etcd:latest
+      image: quay.io/coreos/etcd:v3.5.4
       name: etcd
       ports:
         - containerPort: 2379

--- a/config/dependencies/quickstart.yaml
+++ b/config/dependencies/quickstart.yaml
@@ -38,7 +38,7 @@ spec:
         - http://0.0.0.0:2379
         - --advertise-client-urls
         - http://0.0.0.0:2379
-      image: quay.io/coreos/etcd:latest
+      image: quay.io/coreos/etcd:v3.5.4
       name: etcd
       ports:
         - containerPort: 2379


### PR DESCRIPTION
The 'latest' tag is actually around four years old (corresponding to etcd 3.3.8), so this uses
a newer version for the quickstart/FVTs.
