### PR TITLE
refac: Replace custom StringSet impl with apimachinery sets.String

### DIFF
--- a/controllers/modelmesh/constraints.go
+++ b/controllers/modelmesh/constraints.go
@@ -68,5 +68,5 @@ func (m *Deployment) addModelTypeConstraints(deployment *appsv1.Deployment) erro
 
 func generateLabelsEnvVar(rt *api.ServingRuntime) string {
 	labelSet := GetServingRuntimeSupportedModelTypeLabelSet(rt)
-	return strings.Join(labelSet.ToSlice(), ",")
+	return strings.Join(labelSet.List(), ",")
 }

--- a/controllers/modelmesh/model_type_labels.go
+++ b/controllers/modelmesh/model_type_labels.go
@@ -14,49 +14,25 @@
 package modelmesh
 
 import (
-	"sort"
-
 	api "github.com/kserve/modelmesh-serving/apis/serving/v1alpha1"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-type StringSet map[string]struct{}
-
-var exists = struct{}{} // empty struct placeholder
-
-func (ss StringSet) Add(s string) {
-	ss[s] = exists
-}
-
-func (ss StringSet) Contains(s string) bool {
-	_, found := ss[s]
-	return found
-}
-
-func (ss StringSet) ToSlice() []string {
-	strs := make([]string, 0, len(ss))
-	for s := range ss {
-		strs = append(strs, s)
-	}
-	// map keys are not ordered, so we sort them
-	sort.Strings(strs)
-	return strs
-}
-
-func GetServingRuntimeSupportedModelTypeLabelSet(rt *api.ServingRuntime) StringSet {
-	set := make(StringSet, 2*len(rt.Spec.SupportedModelFormats)+1)
+func GetServingRuntimeSupportedModelTypeLabelSet(rt *api.ServingRuntime) sets.String {
+	set := make(sets.String, 2*len(rt.Spec.SupportedModelFormats)+1)
 
 	// model type labels
 	for _, t := range rt.Spec.SupportedModelFormats {
 		// only include model type labels when autoSelect is true
 		if t.AutoSelect != nil && *t.AutoSelect {
-			set.Add("mt:" + t.Name)
+			set.Insert("mt:" + t.Name)
 			if t.Version != nil {
-				set.Add("mt:" + t.Name + ":" + *t.Version)
+				set.Insert("mt:" + t.Name + ":" + *t.Version)
 			}
 		}
 	}
 	// runtime label
-	set.Add("rt:" + rt.Name)
+	set.Insert("rt:" + rt.Name)
 	return set
 }
 

--- a/controllers/modelmesh/model_type_labels_test.go
+++ b/controllers/modelmesh/model_type_labels_test.go
@@ -14,7 +14,6 @@
 package modelmesh
 
 import (
-	"strings"
 	"testing"
 
 	api "github.com/kserve/modelmesh-serving/apis/serving/v1alpha1"
@@ -69,7 +68,7 @@ func TestGetServingRuntimeSupportedModelTypeLabelSet(t *testing.T) {
 		t.Errorf("Length of set %v should be %d, but got %d", labelSet, len(expectedLabels), len(labelSet))
 	}
 	for _, e := range expectedLabels {
-		if !labelSet.Contains(e) {
+		if !labelSet.Has(e) {
 			t.Errorf("Missing expected entry [%s] in set: %v", e, labelSet)
 		}
 	}
@@ -128,77 +127,5 @@ func TestGetPredictorModelTypeLabel(t *testing.T) {
 				t.Errorf("Got wrong predictor label, expected [%s], got [%s]", tt.expectedLabel, label)
 			}
 		})
-	}
-}
-
-func makeStringSet(input []string) StringSet {
-	ss := make(StringSet, len(input))
-	for _, s := range input {
-		ss.Add(s)
-	}
-	return ss
-}
-
-func TestStringSetContains(t *testing.T) {
-	inputs := []string{"cat", "frog", "aardvark", "aardvark", "aardvark"}
-	ss := makeStringSet(inputs)
-
-	// should contain these
-	if !ss.Contains("cat") {
-		t.Errorf("Missing expected entry [cat] in set: %v", ss)
-	}
-	if !ss.Contains("aardvark") {
-		t.Errorf("Missing expected entry [aardvark] in set: %v", ss)
-	}
-	if !ss.Contains("frog") {
-		t.Errorf("Missing expected entry [frog] in set: %v", ss)
-	}
-	// and not contain these
-	if ss.Contains("billy goat") {
-		t.Errorf("Unexpected entry [billy goat] in set: %v", ss)
-	}
-	if ss.Contains(".") {
-		t.Errorf("Unexpected entry [.] in set: %v", ss)
-	}
-}
-
-func TestStringSetToSlice(t *testing.T) {
-	inputs := []string{"c", "f", "a", "a", "f", "a"}
-	ss := makeStringSet(inputs)
-
-	hasC := false
-	hasF := false
-	hasA := false
-
-	ssSlice := ss.ToSlice()
-
-	for i, s := range ssSlice {
-		// each entry should only show up once
-		if s == "c" && !hasC {
-			hasC = true
-			continue
-		}
-		if s == "f" && !hasF {
-			hasF = true
-			continue
-		}
-		if s == "a" && !hasA {
-			hasA = true
-			continue
-		}
-		t.Errorf("Unexpected entry in ToSlice at index %d: %v", i, ssSlice)
-	}
-	if !hasC || !hasA || !hasF {
-		t.Errorf("Missing expected entry in ToSlice: %v", ssSlice)
-	}
-
-	// test that the order of entries in ToSlice is consistent
-	expected := strings.Join(ss.ToSlice(), ",")
-	for i := 1; i <= 20; i++ {
-		ssNew := makeStringSet(inputs)
-		got := strings.Join(ssNew.ToSlice(), ",")
-		if got != expected {
-			t.Fatalf("Expected order of ToSlice to result in %v but got %v", expected, got)
-		}
 	}
 }

--- a/controllers/servingruntime_controller.go
+++ b/controllers/servingruntime_controller.go
@@ -354,7 +354,7 @@ func runtimeSupportsPredictor(rt *api.ServingRuntime, p *api.Predictor) bool {
 	predictorLabel := modelmesh.GetPredictorModelTypeLabel(p)
 
 	// if the runtime has the predictor's label, then it supports that predictor
-	return runtimeLabelSet.Contains(predictorLabel)
+	return runtimeLabelSet.Has(predictorLabel)
 }
 
 // getRuntimesSupportingPredictor returns a list of keys for runtimes that support the predictor p

--- a/controllers/servingruntime_validator.go
+++ b/controllers/servingruntime_validator.go
@@ -17,6 +17,8 @@ import (
 	"fmt"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"errors"
 
 	corev1 "k8s.io/api/core/v1"
@@ -103,8 +105,8 @@ func validateContainer(c *corev1.Container) error {
 		}
 
 		// Check for conflicting port usage
-		if internal, ok := internalPorts[p.ContainerPort]; ok {
-			return fmt.Errorf("Port %d is reserved for internal use", internal)
+		if _, ok := internalPorts[p.ContainerPort]; ok {
+			return fmt.Errorf("Port %d is reserved for internal use", p.ContainerPort)
 		}
 		// Reserve a range for future use
 		// ascii 'm' is 109. ModelMesh -> mm -> m*m = 11881
@@ -127,8 +129,8 @@ func validateVolumes(rt *api.ServingRuntime) error {
 	return nil
 }
 
-func checkName(name string, internalNames map[string]interface{}, logStr string) error {
-	if _, ok := internalNames[name]; ok {
+func checkName(name string, internalNames sets.String, logStr string) error {
+	if internalNames.Has(name) {
 		return fmt.Errorf("%s %s is reserved for internal use", logStr, name)
 	}
 
@@ -138,36 +140,32 @@ func checkName(name string, internalNames map[string]interface{}, logStr string)
 	return nil
 }
 
-var internalContainerNames = map[string]interface{}{
-	modelmesh.ModelMeshContainerName: nil,
-	modelmesh.RESTProxyContainerName: nil,
-	modelmesh.PullerContainerName:    nil,
+var internalContainerNames = sets.NewString(
+	modelmesh.ModelMeshContainerName,
+	modelmesh.RESTProxyContainerName,
+	modelmesh.PullerContainerName,
+)
+
+var internalOnlyVolumeMounts = sets.NewString(
+	modelmesh.ConfigStorageMount,
+	modelmesh.EtcdVolume,
+	modelmesh.InternalConfigMapName,
+	modelmesh.SocketVolume,
+)
+
+var internalNamedPorts = sets.NewString("grpc", "http", "prometheus")
+
+var internalPorts = map[int32]struct{}{
+	8080: {}, // is used for LiteLinks communication in Model Mesh
+	8085: {}, // is the port the built-in adapter listens on
+	8089: {}, // is used for Model Mesh probes
+	8090: {}, // is used for default preStop hooks
 }
 
-var internalOnlyVolumeMounts = map[string]interface{}{
-	modelmesh.ConfigStorageMount:    nil,
-	modelmesh.EtcdVolume:            nil,
-	modelmesh.InternalConfigMapName: nil,
-	modelmesh.SocketVolume:          nil,
-}
-
-var internalNamedPorts = map[string]interface{}{
-	"grpc":       nil,
-	"http":       nil,
-	"prometheus": nil,
-}
-
-var internalPorts = map[int32]interface{}{
-	8080: nil, // is used for LiteLinks communication in Model Mesh
-	8085: nil, // is the port the built-in adapter listens on
-	8089: nil, // is used for Model Mesh probes
-	8090: nil, // is used for default preStop hooks
-}
-
-var internalVolumes = map[string]interface{}{
-	modelmesh.ConfigStorageMount:    nil,
-	modelmesh.EtcdVolume:            nil,
-	modelmesh.InternalConfigMapName: nil,
-	modelmesh.SocketVolume:          nil,
-	modelmesh.ModelsDirVolume:       nil,
-}
+var internalVolumes = sets.NewString(
+	modelmesh.ConfigStorageMount,
+	modelmesh.EtcdVolume,
+	modelmesh.InternalConfigMapName,
+	modelmesh.SocketVolume,
+	modelmesh.ModelsDirVolume,
+)

--- a/controllers/servingruntime_validator.go
+++ b/controllers/servingruntime_validator.go
@@ -14,14 +14,12 @@
 package controllers
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/util/sets"
-
-	"errors"
-
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	api "github.com/kserve/modelmesh-serving/apis/serving/v1alpha1"
 	"github.com/kserve/modelmesh-serving/controllers/modelmesh"

--- a/controllers/servingruntime_validator.go
+++ b/controllers/servingruntime_validator.go
@@ -103,7 +103,7 @@ func validateContainer(c *corev1.Container) error {
 		}
 
 		// Check for conflicting port usage
-		if _, ok := internalPorts[p.ContainerPort]; ok {
+		if internalPorts.Has(p.ContainerPort) {
 			return fmt.Errorf("Port %d is reserved for internal use", p.ContainerPort)
 		}
 		// Reserve a range for future use
@@ -153,12 +153,12 @@ var internalOnlyVolumeMounts = sets.NewString(
 
 var internalNamedPorts = sets.NewString("grpc", "http", "prometheus")
 
-var internalPorts = map[int32]struct{}{
-	8080: {}, // is used for LiteLinks communication in Model Mesh
-	8085: {}, // is the port the built-in adapter listens on
-	8089: {}, // is used for Model Mesh probes
-	8090: {}, // is used for default preStop hooks
-}
+var internalPorts = sets.NewInt32(
+	8080, // is used for LiteLinks communication in Model Mesh
+	8085, // is the port the built-in adapter listens on
+	8089, // is used for Model Mesh probes
+	8090, // is used for default preStop hooks
+)
 
 var internalVolumes = sets.NewString(
 	modelmesh.ConfigStorageMount,


### PR DESCRIPTION
#### Motivation

Our code included a simple `StringSet` implementation, but there's an equivalent type in the `k8s.io/apimachinery/pkg/util/sets` package.

#### Modifications

- Remove `StringSet` impl and associated unit tests
- Replace current use of `StringSet` with sets.String
- Use sets.String in `servingruntime_validator` rather than explicit maps
- Small fix to container port check in `servingruntime_validator`

#### Result

Less/clearer code, better reuse

Signed-off-by: Nick Hill <nickhill@us.ibm.com>