### PR TITLE
chore: convert quickstart/fvt pods into deployments

### DIFF
--- a/config/dependencies/fvt.yaml
+++ b/config/dependencies/fvt.yaml
@@ -24,41 +24,49 @@ spec:
   selector:
     app: etcd
 ---
-apiVersion: v1
-kind: Pod
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   labels:
     app: etcd
   name: etcd
 spec:
-  containers:
-    - command:
-        - etcd
-        - --listen-client-urls
-        - http://0.0.0.0:2379
-        - --advertise-client-urls
-        - http://0.0.0.0:2379
-      image: quay.io/coreos/etcd:v3.5.4
-      name: etcd
-      ports:
-        - containerPort: 2379
-          name: client
-          protocol: TCP
-        - containerPort: 2380
-          name: server
-          protocol: TCP
-  restartPolicy: Always
+  replicas: 1
+  selector:
+    matchLabels:
+      app: etcd
+  template:
+    metadata:
+      labels:
+        app: etcd
+    spec:
+      containers:
+        - command:
+            - etcd
+            - --listen-client-urls
+            - http://0.0.0.0:2379
+            - --advertise-client-urls
+            - http://0.0.0.0:2379
+          image: quay.io/coreos/etcd:v3.5.4
+          name: etcd
+          ports:
+            - containerPort: 2379
+              name: client
+              protocol: TCP
+            - containerPort: 2380
+              name: server
+              protocol: TCP
 ---
 apiVersion: v1
+kind: Secret
+metadata:
+  name: model-serving-etcd
 stringData:
   etcd_connection: |
     {
       "endpoints": "http://etcd:2379",
       "root_prefix": "modelmesh-serving"
     }
-kind: Secret
-metadata:
-  name: model-serving-etcd
 ---
 apiVersion: v1
 kind: Service
@@ -73,25 +81,33 @@ spec:
   selector:
     app: minio
 ---
-apiVersion: v1
-kind: Pod
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   labels:
     app: minio
   name: minio
 spec:
-  containers:
-    - args:
-        - server
-        # - /data
-        - /data1
-      env:
-        - name: MINIO_ACCESS_KEY
-          value: AKIAIOSFODNN7EXAMPLE
-        - name: MINIO_SECRET_KEY
-          value: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-      image: kserve/modelmesh-minio-dev-examples:latest
-      name: minio
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio
+  template:
+    metadata:
+      labels:
+        app: minio
+    spec:
+      containers:
+        - args:
+            - server
+            - /data1
+          env:
+            - name: MINIO_ACCESS_KEY
+              value: AKIAIOSFODNN7EXAMPLE
+            - name: MINIO_SECRET_KEY
+              value: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+          image: kserve/modelmesh-minio-dev-examples:latest
+          name: minio
 ---
 apiVersion: v1
 kind: Secret

--- a/config/dependencies/quickstart.yaml
+++ b/config/dependencies/quickstart.yaml
@@ -24,41 +24,49 @@ spec:
   selector:
     app: etcd
 ---
-apiVersion: v1
-kind: Pod
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   labels:
     app: etcd
   name: etcd
 spec:
-  containers:
-    - command:
-        - etcd
-        - --listen-client-urls
-        - http://0.0.0.0:2379
-        - --advertise-client-urls
-        - http://0.0.0.0:2379
-      image: quay.io/coreos/etcd:v3.5.4
-      name: etcd
-      ports:
-        - containerPort: 2379
-          name: client
-          protocol: TCP
-        - containerPort: 2380
-          name: server
-          protocol: TCP
-  restartPolicy: Always
+  replicas: 1
+  selector:
+    matchLabels:
+      app: etcd
+  template:
+    metadata:
+      labels:
+        app: etcd
+    spec:
+      containers:
+        - command:
+            - etcd
+            - --listen-client-urls
+            - http://0.0.0.0:2379
+            - --advertise-client-urls
+            - http://0.0.0.0:2379
+          image: quay.io/coreos/etcd:v3.5.4
+          name: etcd
+          ports:
+            - containerPort: 2379
+              name: client
+              protocol: TCP
+            - containerPort: 2380
+              name: server
+              protocol: TCP
 ---
 apiVersion: v1
+kind: Secret
+metadata:
+  name: model-serving-etcd
 stringData:
   etcd_connection: |
     {
       "endpoints": "http://etcd:2379",
       "root_prefix": "modelmesh-serving"
     }
-kind: Secret
-metadata:
-  name: model-serving-etcd
 ---
 apiVersion: v1
 kind: Service
@@ -73,26 +81,35 @@ spec:
   selector:
     app: minio
 ---
-apiVersion: v1
-kind: Pod
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   labels:
     app: minio
   name: minio
 spec:
-  containers:
-    - args:
-        - server
-        # - /data
-        - /data1
-      env:
-        - name: MINIO_ACCESS_KEY
-          value: AKIAIOSFODNN7EXAMPLE
-        - name: MINIO_SECRET_KEY
-          value: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-      # image: quay.io/cloudservices/minio:latest
-      image: kserve/modelmesh-minio-examples:latest
-      name: minio
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio
+  template:
+    metadata:
+      labels:
+        app: minio
+    spec:
+      containers:
+        - args:
+            - server
+            # - /data
+            - /data1
+          env:
+            - name: MINIO_ACCESS_KEY
+              value: AKIAIOSFODNN7EXAMPLE
+            - name: MINIO_SECRET_KEY
+              value: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+          # image: quay.io/cloudservices/minio:latest
+          image: kserve/modelmesh-minio-examples:latest
+          name: minio
 ---
 apiVersion: v1
 kind: Secret

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -28,6 +28,8 @@ kubectl create namespace modelmesh-serving
 This will install ModelMesh serving in the `modelmesh-serving` namespace, along with an etcd and MinIO instances.
 Eventually after running this script, you should see a `Successfully installed ModelMesh Serving!` message.
 
+**Note**: These etcd and MinIO deployments are intended for development/experimentation and not for production.
+
 To see more details about installation, click [here](./install/install-script.md).
 
 ### Verify installation

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -240,8 +240,8 @@ if [[ $quickstart == "true" ]]; then
   kubectl apply -f dependencies/quickstart.yaml
 
   info "Waiting for dependent pods to be up..."
-  wait_for_pods_ready "--field-selector metadata.name=etcd"
-  wait_for_pods_ready "--field-selector metadata.name=minio"
+  wait_for_pods_ready "-l app=etcd"
+  wait_for_pods_ready "-l app=minio"
 fi
 
 # FVT resources
@@ -250,8 +250,8 @@ if [[ $fvt == "true" ]]; then
   kubectl apply -f dependencies/fvt.yaml
 
   info "Waiting for dependent pods to be up..."
-  wait_for_pods_ready "--field-selector metadata.name=etcd"
-  wait_for_pods_ready "--field-selector metadata.name=minio"
+  wait_for_pods_ready "-l app=etcd"
+  wait_for_pods_ready "-l app=minio"
 fi
 
 if ! kubectl get secret model-serving-etcd >/dev/null; then


### PR DESCRIPTION
The minio and etcd instances now use deployments instead of pods to provide
some level of resiliency. 

The quickstart doc was also updated with a small disclaimer about these deployments.