### PR TITLE
fix: Fix possible nil pointer dereference; minor log improvements

### DIFF
--- a/controllers/modelmesh/modelmesh.go
+++ b/controllers/modelmesh/modelmesh.go
@@ -157,7 +157,7 @@ func (m *Deployment) Apply(ctx context.Context) error {
 }
 
 func (m *Deployment) Delete(ctx context.Context, client client.Client) error {
-	m.Log.Info("Deleting model mesh deployment ", "m", m)
+	m.Log.Info("Deleting modelmesh deployment ", "name", m.Name, "namespace", m.Namespace)
 	return config.Delete(client, m.Owner, "config/internal/base/deployment.yaml.tmpl", m)
 }
 

--- a/controllers/servingruntime_controller.go
+++ b/controllers/servingruntime_controller.go
@@ -103,9 +103,8 @@ func (r *ServingRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	if err != nil {
 		return RequeueResult, err
 	}
-	var runtimes *kserveapi.ServingRuntimeList
+	runtimes := &kserveapi.ServingRuntimeList{}
 	if mmEnabled {
-		runtimes = &kserveapi.ServingRuntimeList{}
 		if err = r.Client.List(ctx, runtimes, client.InNamespace(req.Namespace)); err != nil {
 			return RequeueResult, err
 		}

--- a/main.go
+++ b/main.go
@@ -118,12 +118,12 @@ func main() {
 		if podName != "" {
 			if matches := regexp.MustCompile("(.*)-.*-.*").FindStringSubmatch(podName); len(matches) == 2 {
 				deployment := matches[1]
-				setupLog.Info("Use controller deployment from POD_NAME", "Deployment", deployment)
+				setupLog.Info("Using controller deployment name from POD_NAME", "Deployment", deployment)
 				controllerDeploymentName = deployment
 			}
 		}
 		if controllerDeploymentName == "" {
-			setupLog.Info("Skip empty Controller deployment from Env Var, use default",
+			setupLog.Info("Controller deployment name env var not provided, using default",
 				"name", DefaultControllerName)
 			controllerDeploymentName = DefaultControllerName
 		}


### PR DESCRIPTION
#### Motivation

During unrelated testing I found a bug where a nil pointer deref could occur if ServingRuntimes are encountered in namespaces in which modelmesh isn't enabled (i.e. not the controller's namespace and without the `modelmesh-enabled=true` label).

#### Modifications

- Move list pointer initialization to ensure it won't be nil
- Improve some badly worded log statements and one containing excessive detail (full deployment contents rather than just name)

Signed-off-by: Nick Hill <nickhill@us.ibm.com>