### PR TITLE
chore: Update K8s version in GH Actions FVTs

### DIFF
--- a/.github/workflows/run-fvt.yml
+++ b/.github/workflows/run-fvt.yml
@@ -21,11 +21,11 @@ jobs:
           go-version: '1.17.3'
       - name: Setup Minikube
         run: |
-          wget --no-verbose https://github.com/kubernetes/minikube/releases/download/v1.21.0/minikube-linux-amd64
+          wget --no-verbose https://github.com/kubernetes/minikube/releases/download/v1.25.1/minikube-linux-amd64
           sudo cp minikube-linux-amd64 /usr/local/bin/minikube
           sudo chmod 755 /usr/local/bin/minikube
           sudo apt-get install -y conntrack socat
-          minikube start --driver=none --kubernetes-version v1.20.7
+          minikube start --driver=none --kubernetes-version v1.22.10
       - name: Check pods
         run: |
           sleep 30


### PR DESCRIPTION
**Motivation**

Kubeflow/KServe are targeting K8s 1.22, so ModelMesh functional tests should test on this version.

**Modifications**

The GitHub Actions workflow for FVTs was increased to 1.22.10 from 1.20.7. The Minikube version used
was also increased.

**Result**

Functional tests now run on K8s 1.22.