### PR TITLE
feat: Enable ModelMetadata endpoint

### DIFF
--- a/controllers/modelmesh/cluster_config.go
+++ b/controllers/modelmesh/cluster_config.go
@@ -39,6 +39,10 @@ var dataPlaneApiJsonConfigBytes = []byte(`{
             "idExtractionPath": [1],
             "vModelId": true
         },
+        "inference.GRPCInferenceService/ModelMetadata": {
+            "idExtractionPath": [1],
+            "vModelId": true
+        },
         "tensorflow.serving.PredictionService/Predict": {
             "idExtractionPath": [1, 1],
             "vModelId": true

--- a/fvt/fvtclient.go
+++ b/fvt/fvtclient.go
@@ -425,6 +425,18 @@ func (fvt *FVTClient) RunKfsInference(req *inference.ModelInferRequest) (*infere
 	return grpcClient.ModelInfer(ctx, req)
 }
 
+func (fvt *FVTClient) RunKfsModelMetadata(req *inference.ModelMetadataRequest) (*inference.ModelMetadataResponse, error) {
+	if fvt.grpcConn == nil {
+		return nil, errors.New("you must connect to model mesh before running a model metadata request")
+	}
+
+	grpcClient := inference.NewGRPCInferenceServiceClient(fvt.grpcConn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	return grpcClient.ModelMetadata(ctx, req)
+}
+
 func (fvt *FVTClient) RunKfsRestInference(modelName string, body []byte, tls bool) (string, error) {
 	if fvt.restConn == nil {
 		return "", errors.New("you must connect to model mesh before running an inference")

--- a/fvt/predictor/predictor_test.go
+++ b/fvt/predictor/predictor_test.go
@@ -370,6 +370,24 @@ var _ = Describe("Predictor", func() {
 			Expect(err.Error()).To(ContainSubstring("model expects 'FP32'"))
 			Expect(inferResponse).To(BeNil())
 		})
+
+		It("should return model metadata", func() {
+			modelMetadataRequest := &inference.ModelMetadataRequest{
+				Name: tfPredictorName,
+			}
+			modelMetadataResponse, err := FVTClientInstance.RunKfsModelMetadata(modelMetadataRequest)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(modelMetadataResponse).ToNot(BeNil())
+
+			Expect(modelMetadataResponse.Name).To(HavePrefix(tfPredictorName))
+			Expect(modelMetadataResponse.Inputs).To(HaveLen(1))
+			Expect(modelMetadataResponse.Outputs).To(HaveLen(1))
+
+			Expect(modelMetadataResponse.Inputs[0].Name).To(Equal("inputs"))
+			Expect(modelMetadataResponse.Inputs[0].Shape).To(Equal([]int64{-1, 784}))
+			Expect(modelMetadataResponse.Inputs[0].Datatype).To(Equal("FP32"))
+		})
 	})
 
 	var _ = Describe("Keras inference", Ordered, func() {
@@ -425,6 +443,25 @@ var _ = Describe("Predictor", func() {
 			Expect(inferResponse).To(BeNil())
 			Expect(err.Error()).To(ContainSubstring("INVALID_ARGUMENT: unexpected shape for input"))
 		})
+
+		It("should return model metadata", func() {
+			modelMetadataRequest := &inference.ModelMetadataRequest{
+				Name: kerasPredictorName,
+			}
+			modelMetadataResponse, err := FVTClientInstance.RunKfsModelMetadata(modelMetadataRequest)
+
+			fmt.Println(modelMetadataResponse)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(modelMetadataResponse).ToNot(BeNil())
+
+			Expect(modelMetadataResponse.Name).To(HavePrefix(kerasPredictorName))
+			Expect(modelMetadataResponse.Inputs).To(HaveLen(1))
+			Expect(modelMetadataResponse.Outputs).To(HaveLen(1))
+
+			Expect(modelMetadataResponse.Inputs[0].Name).To(Equal("conv2d_input"))
+			Expect(modelMetadataResponse.Inputs[0].Shape).To(Equal([]int64{-1, 28, 28, 1}))
+			Expect(modelMetadataResponse.Inputs[0].Datatype).To(Equal("FP32"))
+		})
 	})
 
 	var _ = Describe("ONNX inference", Ordered, func() {
@@ -469,6 +506,24 @@ var _ = Describe("Predictor", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(inferResponse).To(BeNil())
 			Expect(err.Error()).To(ContainSubstring("INVALID_ARGUMENT: unexpected shape for input"))
+		})
+
+		It("should return model metadata", func() {
+			modelMetadataRequest := &inference.ModelMetadataRequest{
+				Name: onnxPredictorName,
+			}
+			modelMetadataResponse, err := FVTClientInstance.RunKfsModelMetadata(modelMetadataRequest)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(modelMetadataResponse).ToNot(BeNil())
+			Expect(modelMetadataResponse.Name).To(HavePrefix(onnxPredictorName))
+
+			Expect(modelMetadataResponse.Inputs).To(HaveLen(1))
+			Expect(modelMetadataResponse.Outputs).To(HaveLen(1))
+
+			Expect(modelMetadataResponse.Inputs[0].Name).To(Equal("Input3"))
+			Expect(modelMetadataResponse.Inputs[0].Shape).To(Equal([]int64{1, 1, 28, 28}))
+			Expect(modelMetadataResponse.Inputs[0].Datatype).To(Equal("FP32"))
 		})
 	})
 
@@ -568,6 +623,18 @@ var _ = Describe("Predictor", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("1 should be equal to 64"))
 		})
+
+		It("should return model metadata", func() {
+			modelMetadataRequest := &inference.ModelMetadataRequest{
+				Name: mlsPredictorName,
+			}
+			modelMetadataResponse, err := FVTClientInstance.RunKfsModelMetadata(modelMetadataRequest)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(modelMetadataResponse).ToNot(BeNil())
+			// Only name is returned.
+			Expect(modelMetadataResponse.Name).To(HavePrefix(mlsPredictorName))
+		})
 	})
 
 	var _ = Describe("XGBoost inference", Ordered, func() {
@@ -658,6 +725,25 @@ var _ = Describe("Predictor", func() {
 			Expect(err.Error()).To(ContainSubstring("INVALID_ARGUMENT: unexpected shape for input"))
 			Expect(inferResponse).To(BeNil())
 		})
+
+		It("should return model metadata", func() {
+			modelMetadataRequest := &inference.ModelMetadataRequest{
+				Name: ptPredictorName,
+			}
+			modelMetadataResponse, err := FVTClientInstance.RunKfsModelMetadata(modelMetadataRequest)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(modelMetadataResponse).ToNot(BeNil())
+			Expect(modelMetadataResponse.Name).To(HavePrefix(ptPredictorName))
+
+			Expect(modelMetadataResponse.Inputs).To(HaveLen(1))
+			Expect(modelMetadataResponse.Outputs).To(HaveLen(1))
+
+			Expect(modelMetadataResponse.Inputs[0].Name).To(Equal("INPUT__0"))
+			Expect(modelMetadataResponse.Inputs[0].Shape).To(Equal([]int64{-1, 3, 32, 32}))
+			Expect(modelMetadataResponse.Inputs[0].Datatype).To(Equal("FP32"))
+		})
+
 	})
 
 	// This an inference testcase for pytorch that mandates schema in config.pbtxt


### PR DESCRIPTION
**Motivation**

Enable users to use the KServe v2 ModelMetadata endpoint with Triton and MLServer ServingRuntimes.

**Modifications**

- ModelMetadata added to dataplane config in controller.
- Some functional tests were added to test the newly exposed endpoint.

**Result**

Users can send gRPC requests to the ModelMetadata endpoint. Primarily useful with Triton as MLServer only seems to return the name of the model.

Partially-Closes: #136