### PR TITLE
feat: Support azure blob storageURIs in Isvc

### DIFF
--- a/pkg/predictor_source/inferenceservice_registry_test.go
+++ b/pkg/predictor_source/inferenceservice_registry_test.go
@@ -14,6 +14,7 @@
 package predictor_source
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
@@ -253,6 +254,33 @@ func TestProcessInferenceServiceStorage_S3UriProcessing(t *testing.T) {
 	assert.Equal(t, uriPath, modelPath)
 	assert.Equal(t, uriBucket, parameters["bucket"])
 	assert.Equal(t, "s3", parameters["type"])
+}
+
+func TestProcessInferenceServiceStorage_AzureUriProcessing(t *testing.T) {
+	uriAccount := "az-account"
+	uriContainer := "az-container"
+	uriPath := "some/path/in/the/uri"
+	uri := fmt.Sprintf("https://%s.%s/%s/%s", uriAccount, azureBlobHostSuffix, uriContainer, uriPath)
+
+	nname := types.NamespacedName{Name: "tm-test-model", Namespace: "modelmesh-serving"}
+	inferenceService := &v1beta1.InferenceService{
+		Spec: v1beta1.InferenceServiceSpec{
+			Predictor: v1beta1.PredictorSpec{
+				SKLearn: &v1beta1.SKLearnSpec{
+					PredictorExtensionSpec: v1beta1.PredictorExtensionSpec{
+						StorageURI: &uri,
+					},
+				},
+			},
+		},
+	}
+
+	_, parameters, modelPath, _, err := processInferenceServiceStorage(inferenceService, nname)
+	assert.NoError(t, err)
+	assert.Equal(t, uriPath, modelPath)
+	assert.Equal(t, uriAccount, parameters["account_name"])
+	assert.Equal(t, uriContainer, parameters["container"])
+	assert.Equal(t, "azure", parameters["type"])
 }
 
 func TestProcessInferenceServiceStorage_OverlappingParameters(t *testing.T) {


### PR DESCRIPTION
#### Motivation

The model puller now supports pulling from Azure Blob Storage. We should allow users to pass in an
Azure Blob Storage URI as an InferenceService Predictor `storageUri`.

#### Modifications

Storage parsing logic now parses Azure Blob URIs and passes the relevant info the puller.

#### Result

Users can now pass in Azure Blob Storage URIs as part of `storageUri`.