### PR TITLE
docs: Add rest-proxy docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ ModelMesh Serving makes use of two core Kubernetes Custom Resource types:
 
 The Pods that correspond to a particular `ServingRuntime` are started only if/when there are one or more defined `Predictor`s that require them.
 
-We have standardized on the [KServe v2 data plane API](inference/ks-v2-grpc.md) for inferencing, this is supported for all of the built-in model types. Only the gRPC version of this API is supported in this version of ModelMesh Serving, REST support will be coming soon. Custom runtimes are free to use gRPC Service APIs for inferencing, including the KSv2 API.
+We have standardized on the [KServe v2 data plane API](inference/ks-v2-grpc.md) for inferencing, this is supported for all of the built-in model types. We now have support for both the gRPC and REST versions of this. REST is not supported for custom runtimes, but they are free to use any gRPC Service APIs for inferencing including the KSv2 API.
 
 System-wide configuration parameters can be set by [creating a ConfigMap](configuration/) with name `model-serving-config`.
 

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -2,7 +2,7 @@
 
 System-wide configuration parameters can be set by creating a ConfigMap with name `model-serving-config`. It should contain a single key named `config.yaml`, whose value is a yaml doc containing the configuration. All parameters have defaults and are optional. If the ConfigMap does not exist, all parameters will take their defaults.
 
-The configuration can be updated at runtime and will take effect immediately. Be aware however that certain changes could cause temporary disruption to the service - in particular changing the service name, port, TLS configuration and/or headlessness.
+The configuration can be updated at runtime and will take effect immediately. Be aware however that certain changes could cause temporary disruption to the service - in particular changing the service name, port, TLS configuration, and/or headlessness, or enabling/disabling the REST inferencing port.
 
 Example:
 
@@ -18,6 +18,8 @@ data:
     inferenceServicePort: 8033
     podsPerRuntime: 2
     metrics:
+      enabled: true
+    restProxy:
       enabled: true
     runtimePodLabels:
       app: myApp
@@ -85,6 +87,12 @@ prometheus.io/port: 2112
 prometheus.io/scheme: https
 prometheus.io/scrape: true
 ```
+
+## Enabling REST inferencing endpoint
+
+REST inferencing support is enabled by default, but it requires slightly larger overall resource allocations due to the current proxy implementation. When enabled, the default port is 8008, and ModelMesh Serving will accept both REST and gRPC inferencing requests.
+
+See the [Deployed Components section](../install/README.md#deployed-components) for more information on the additional CPU and Memory footprint when REST inferencing is enabled.
 
 ## Exposing an external endpoint using an OpenShift route
 

--- a/docs/predictors/run-inference.md
+++ b/docs/predictors/run-inference.md
@@ -1,6 +1,6 @@
 # Send an inference request to your Predictor
 
-Currently, only gRPC requests are supported by ModelMesh. However, if the `restProxy` is `enabled` in the ModelMesh Serving [config](../configuration) (which it is by default), then REST inference requests are enabled via [KServe V2 REST proxies](https://github.com/kserve/rest-proxy). This allows sending requests using the KServe V2 REST Predict Protocol to ModelMesh models.
+Currently, only gRPC requests are supported by ModelMesh. However, if the `restProxy` is `enabled` in the ModelMesh Serving [config](../configuration) (which it is by default), then REST inference requests are enabled via [KServe V2 REST proxies](https://github.com/kserve/rest-proxy). This allows sending requests using the KServe V2 REST Predict Protocol to ModelMesh models. However, this proxy does not work in conjunction with custom serving runtimes that expose different gRPC protobuf APIs.
 
 1. [Inference using gRPC](#inference-using-grpc)
 2. [Inference using REST](#inference-using-rest)
@@ -162,7 +162,7 @@ grpcurl \
 
 ## Inference using REST
 
-> **Note**: The [REST proxy](https://github.com/kserve/rest-proxy) is currently in an alpha state and may still have issues with certain usage scenarios.
+> **Note**: The [REST proxy](https://github.com/kserve/rest-proxy) is currently in an alpha state and may still have issues with certain usage scenarios. When the use case is more performance or resource intensive, consider disabling the REST proxy (it is enabled by default), and using gRPC instead. With the REST proxy enabled, an extra container is deployed in each serving runtime pod which increases resource usage and inference request performance is reduced. See [Configuration](../configuration/README.md) for how to disable/enable the REST inferencing endpoint for ModelMesh ServingRuntimes.
 
 By default, REST requests will go through the `modelmesh-serving` service using port `8008`.
 


### PR DESCRIPTION
Added some docs about rest-proxy that was added internally but not externally.
Also updated the deployment components resource usage chart and added some missing OVMS references.