### PR TITLE
fix: Ensure correct protocolVersion is retrieved

### DIFF
--- a/pkg/predictor_source/inferenceservice_registry.go
+++ b/pkg/predictor_source/inferenceservice_registry.go
@@ -108,9 +108,9 @@ func BuildBasePredictorFromInferenceService(isvc *v1beta1.InferenceService) (*v1
 			},
 		}
 
-		protocolVersion := isvc.Spec.Predictor.GetImplementation().GetProtocol()
-		if protocolVersion != kserveConstants.ProtocolUnknown {
-			p.Spec.ProtocolVersion = &protocolVersion
+		protocolVersion := frameworkSpec.ProtocolVersion
+		if protocolVersion != nil && *protocolVersion != kserveConstants.ProtocolUnknown {
+			p.Spec.ProtocolVersion = protocolVersion
 		}
 
 		// If explicit ServingRuntime was passed in through an annotation


### PR DESCRIPTION
For InferenceServices using the old predictor schema, no
matching runtime is found because GetProtocol generally
returns a protocol even if none is specified in the spec.

This adjusts the logic a bit to pull the ProtocolVersion from the actual spec.

Fixes: #173 