### PR TITLE
chore: Rename roles/rolebindings

### DIFF
--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -15,7 +15,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: controller-leader-election-role
+  name: modelmesh-controller-leader-election-role
 rules:
   - apiGroups:
       - coordination.k8s.io

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -14,11 +14,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: controller-leader-election-rolebinding
+  name: modelmesh-controller-leader-election-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: controller-leader-election-role
+  name: modelmesh-controller-leader-election-role
 subjects:
   - kind: ServiceAccount
     name: modelmesh-controller

--- a/config/rbac/restricted_scc_role.yaml
+++ b/config/rbac/restricted_scc_role.yaml
@@ -14,7 +14,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: modelmesh-controller-restricted-scc
+  name: modelmesh-controller-restricted-scc-role
 rules:
   - apiGroups:
       - security.openshift.io

--- a/config/rbac/restricted_scc_role_binding.yaml
+++ b/config/rbac/restricted_scc_role_binding.yaml
@@ -14,11 +14,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: controller-restricted-scc
+  name: modelmesh-controller-restricted-scc-rolebinding
 subjects:
   - kind: ServiceAccount
     name: modelmesh-controller
 roleRef:
   kind: Role
-  name: modelmesh-controller-restricted-scc
+  name: modelmesh-controller-restricted-scc-role
   apiGroup: rbac.authorization.k8s.io

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -15,7 +15,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: controller-role
+  name: modelmesh-controller-role
 rules:
   - apiGroups:
       - ""

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -14,11 +14,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: controller-rolebinding
+  name: modelmesh-controller-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: controller-role
+  name: modelmesh-controller-role
 subjects:
   - kind: ServiceAccount
     name: modelmesh-controller


### PR DESCRIPTION
#### Motivation

The role/rolebinding names should be more specific to enhance clarity of purpose
and to avoid potential naming collisions.

#### Modifications

Prepended a `modelmesh-` prefix to relevant names. 

#### Result

More clarity for what each role/rolebindings belongs to. 