### PR TITLE
Fix etcd endpoints when etcd is in different namespace

### DIFF
--- a/pkg/mmesh/etcd_secret.go
+++ b/pkg/mmesh/etcd_secret.go
@@ -17,8 +17,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"regexp"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/types"
 
@@ -70,22 +68,6 @@ func (es EtcdSecret) Apply(ctx context.Context, cl client.Client) error {
 
 // Add data to the provided secret
 func (es EtcdSecret) addData(s *corev1.Secret) error {
-	etcdEndpoints := strings.Split(es.EtcdConfig.Endpoints, ",")
-	newEtcdEndpoints := ""
-
-	// For each endpoint, insert controller namespace if not there
-	for i := range etcdEndpoints {
-		re := regexp.MustCompile(`(?:https?://)?([^\\s.:]+)(:\\d+)?`)
-		if se := re.FindStringSubmatchIndex(etcdEndpoints[i]); se != nil {
-			etcdEndpoints[i] = fmt.Sprintf("%s.%s%s", etcdEndpoints[i][:se[3]], es.ControllerNamespace, etcdEndpoints[i][se[3]:])
-		}
-		if i != 0 {
-			newEtcdEndpoints += ","
-		}
-		newEtcdEndpoints += etcdEndpoints[i]
-	}
-
-	es.EtcdConfig.Endpoints = newEtcdEndpoints
 	es.EtcdConfig.RootPrefix = fmt.Sprintf("%s/mm_ns/%s", es.EtcdConfig.RootPrefix, es.Namespace)
 
 	b, err := json.Marshal(es.EtcdConfig)


### PR DESCRIPTION
Fix the etcd endpoints issue when etcd is in different namespace
as described in https://github.com/kserve/modelmesh-serving/issues/186

The default etcd connection endpoints in quick start and fvt yaml are
changed to be placceholder based, and will be replaced during the
install script run. The etcd secret propagation will no longer assume
that etcd resides in the controller namespace.

Signed-off-by: Chin Huang <chhuang@us.ibm.com>

#### Motivation

#### Modifications

#### Result
