### PR TITLE
feat: Ensure modelmesh container comes last in list

### DIFF
--- a/controllers/testdata/servingruntime_controller.golden
+++ b/controllers/testdata/servingruntime_controller.golden
@@ -43,6 +43,95 @@ spec:
                 values:
                 - amd64
       containers:
+      - command:
+        - /opt/app/mlserver-adapter
+        env:
+        - name: ADAPTER_PORT
+          value: "8085"
+        - name: RUNTIME_PORT
+          value: "8001"
+        - name: CONTAINER_MEM_REQ_BYTES
+          valueFrom:
+            resourceFieldRef:
+              containerName: mlserver
+              divisor: "0"
+              resource: requests.memory
+        - name: MEM_BUFFER_BYTES
+          value: "134217728"
+        - name: LOADTIME_TIMEOUT
+          value: "90000"
+        - name: USE_EMBEDDED_PULLER
+          value: "true"
+        - name: RUNTIME_VERSION
+          value: replace
+        image: image:tag
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            httpGet:
+              path: /prestop
+              port: 8090
+              scheme: HTTP
+        name: mlserver-adapter
+        resources:
+          limits:
+            cpu: "2"
+            memory: 512Mi
+          requests:
+            cpu: 50m
+            memory: 96Mi
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /models
+          name: models-dir
+        - mountPath: /storage-config
+          name: storage-config
+          readOnly: true
+      - env:
+        - name: MLSERVER_MODELS_DIR
+          value: /models/_mlserver_models/
+        - name: MLSERVER_GRPC_PORT
+          value: "8001"
+        - name: MLSERVER_HTTP_PORT
+          value: "8002"
+        - name: MLSERVER_LOAD_MODELS_AT_STARTUP
+          value: "false"
+        - name: MLSERVER_MODEL_NAME
+          value: dummy-model-fixme
+        - name: MLSERVER_HOST
+          value: 127.0.0.1
+        - name: MLSERVER_GRPC_MAX_MESSAGE_LENGTH
+          value: "-1"
+        image: mlserver-0:replace
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            httpGet:
+              path: /prestop
+              port: 8090
+              scheme: HTTP
+        name: mlserver
+        resources:
+          limits:
+            cpu: "5"
+            memory: 1Gi
+          requests:
+            cpu: 500m
+            memory: 1Gi
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /models
+          name: models-dir
       - env:
         - name: MM_SERVICE_NAME
           value: modelmesh-serving
@@ -140,364 +229,6 @@ spec:
         - mountPath: /opt/kserve/mmesh/etcd
           name: etcd-config
           readOnly: true
-      - env:
-        - name: MLSERVER_MODELS_DIR
-          value: /models/_mlserver_models/
-        - name: MLSERVER_GRPC_PORT
-          value: "8001"
-        - name: MLSERVER_HTTP_PORT
-          value: "8002"
-        - name: MLSERVER_LOAD_MODELS_AT_STARTUP
-          value: "false"
-        - name: MLSERVER_MODEL_NAME
-          value: dummy-model-fixme
-        - name: MLSERVER_HOST
-          value: 127.0.0.1
-        - name: MLSERVER_GRPC_MAX_MESSAGE_LENGTH
-          value: "-1"
-        image: mlserver-0:replace
-        imagePullPolicy: IfNotPresent
-        lifecycle:
-          preStop:
-            httpGet:
-              path: /prestop
-              port: 8090
-              scheme: HTTP
-        name: mlserver
-        resources:
-          limits:
-            cpu: "5"
-            memory: 1Gi
-          requests:
-            cpu: 500m
-            memory: 1Gi
-        securityContext:
-          capabilities:
-            drop:
-            - ALL
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /models
-          name: models-dir
-      - command:
-        - /opt/app/mlserver-adapter
-        env:
-        - name: ADAPTER_PORT
-          value: "8085"
-        - name: RUNTIME_PORT
-          value: "8001"
-        - name: CONTAINER_MEM_REQ_BYTES
-          valueFrom:
-            resourceFieldRef:
-              containerName: mlserver
-              divisor: "0"
-              resource: requests.memory
-        - name: MEM_BUFFER_BYTES
-          value: "134217728"
-        - name: LOADTIME_TIMEOUT
-          value: "90000"
-        - name: USE_EMBEDDED_PULLER
-          value: "true"
-        - name: RUNTIME_VERSION
-          value: replace
-        image: image:tag
-        imagePullPolicy: IfNotPresent
-        lifecycle:
-          preStop:
-            httpGet:
-              path: /prestop
-              port: 8090
-              scheme: HTTP
-        name: mlserver-adapter
-        resources:
-          limits:
-            cpu: "2"
-            memory: 512Mi
-          requests:
-            cpu: 50m
-            memory: 96Mi
-        securityContext:
-          capabilities:
-            drop:
-            - ALL
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /models
-          name: models-dir
-        - mountPath: /storage-config
-          name: storage-config
-          readOnly: true
-      dnsPolicy: ClusterFirst
-      restartPolicy: Always
-      schedulerName: default-scheduler
-      securityContext: {}
-      terminationGracePeriodSeconds: 90
-      volumes:
-      - emptyDir:
-          sizeLimit: 1536Mi
-        name: models-dir
-      - name: storage-config
-        secret:
-          defaultMode: 420
-          secretName: storage-config
-      - configMap:
-          defaultMode: 420
-          name: tc-config
-        name: tc-config
-      - name: etcd-config
-        secret:
-          defaultMode: 420
-          secretName: secret
-status: {}
-'''
-"REST Proxy configuration deployment should contain REST Proxy container" = '''
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  creationTimestamp: null
-spec:
-  progressDeadlineSeconds: 600
-  replicas: 2
-  revisionHistoryLimit: 10
-  selector:
-    matchLabels:
-      modelmesh-service: modelmesh-serving
-      name: modelmesh-serving-mlserver-0.x
-  strategy:
-    rollingUpdate:
-      maxSurge: 75%
-      maxUnavailable: 15%
-    type: RollingUpdate
-  template:
-    metadata:
-      creationTimestamp: null
-      labels:
-        app.kubernetes.io/instance: modelmesh-controller
-        app.kubernetes.io/managed-by: modelmesh-controller
-        app.kubernetes.io/name: modelmesh-controller
-        modelmesh-service: modelmesh-serving
-        name: modelmesh-serving-mlserver-0.x
-    spec:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/arch
-                operator: In
-                values:
-                - amd64
-      containers:
-      - env:
-        - name: MM_SERVICE_NAME
-          value: modelmesh-serving
-        - name: MM_SVC_GRPC_PORT
-          value: "1234"
-        - name: WKUBE_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: WKUBE_POD_IPADDR
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: MM_LOCATION
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.hostIP
-        - name: KV_STORE
-          value: etcd:/opt/kserve/mmesh/etcd/etcd_connection
-        - name: MM_METRICS
-          value: disabled
-        - name: SHUTDOWN_TIMEOUT_MS
-          value: "90000"
-        - name: INTERNAL_SERVING_GRPC_PORT
-          value: "8001"
-        - name: INTERNAL_GRPC_PORT
-          value: "8085"
-        - name: MM_SVC_GRPC_MAX_MSG_SIZE
-          value: "16777216"
-        - name: MM_KVSTORE_PREFIX
-          value: mm
-        - name: MM_DEFAULT_VMODEL_OWNER
-          value: ksp
-        - name: MM_LABELS
-          value: value: mt:lightgbm,mt:lightgbm:3,mt:sklearn,mt:sklearn:0,mt:xgboost,mt:xgboost:1,pv:grpc-v2,pv:v2,rt:mlserver-0.x
-        - name: MM_TYPE_CONSTRAINTS_PATH
-          value: /etc/watson/mmesh/config/type_constraints
-        - name: MM_DATAPLANE_CONFIG_PATH
-          value: /etc/watson/mmesh/config/dataplane_api_config
-        image: image:tag
-        imagePullPolicy: IfNotPresent
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /opt/kserve/mmesh/stop.sh
-              - wait
-        livenessProbe:
-          failureThreshold: 2
-          httpGet:
-            path: /live
-            port: 8089
-            scheme: HTTP
-          initialDelaySeconds: 90
-          periodSeconds: 30
-          successThreshold: 1
-          timeoutSeconds: 5
-        name: mm
-        ports:
-        - containerPort: 1234
-          name: grpc
-          protocol: TCP
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /ready
-            port: 8089
-            scheme: HTTP
-          initialDelaySeconds: 5
-          periodSeconds: 5
-          successThreshold: 1
-          timeoutSeconds: 1
-        resources:
-          limits:
-            cpu: "3"
-            memory: 448Mi
-          requests:
-            cpu: 300m
-            memory: 448Mi
-        securityContext:
-          capabilities:
-            drop:
-            - ALL
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /etc/watson/mmesh/config
-          name: tc-config
-        - mountPath: /opt/kserve/mmesh/etcd
-          name: etcd-config
-          readOnly: true
-      - env:
-        - name: MLSERVER_MODELS_DIR
-          value: /models/_mlserver_models/
-        - name: MLSERVER_GRPC_PORT
-          value: "8001"
-        - name: MLSERVER_HTTP_PORT
-          value: "8002"
-        - name: MLSERVER_LOAD_MODELS_AT_STARTUP
-          value: "false"
-        - name: MLSERVER_MODEL_NAME
-          value: dummy-model-fixme
-        - name: MLSERVER_HOST
-          value: 127.0.0.1
-        - name: MLSERVER_GRPC_MAX_MESSAGE_LENGTH
-          value: "-1"
-        image: mlserver-0:replace
-        imagePullPolicy: IfNotPresent
-        lifecycle:
-          preStop:
-            httpGet:
-              path: /prestop
-              port: 8090
-              scheme: HTTP
-        name: mlserver
-        resources:
-          limits:
-            cpu: "5"
-            memory: 1Gi
-          requests:
-            cpu: 500m
-            memory: 1Gi
-        securityContext:
-          capabilities:
-            drop:
-            - ALL
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /models
-          name: models-dir
-      - command:
-        - /opt/app/mlserver-adapter
-        env:
-        - name: ADAPTER_PORT
-          value: "8085"
-        - name: RUNTIME_PORT
-          value: "8001"
-        - name: CONTAINER_MEM_REQ_BYTES
-          valueFrom:
-            resourceFieldRef:
-              containerName: mlserver
-              divisor: "0"
-              resource: requests.memory
-        - name: MEM_BUFFER_BYTES
-          value: "134217728"
-        - name: LOADTIME_TIMEOUT
-          value: "90000"
-        - name: USE_EMBEDDED_PULLER
-          value: "true"
-        - name: RUNTIME_VERSION
-          value: replace
-        image: image:tag
-        imagePullPolicy: IfNotPresent
-        lifecycle:
-          preStop:
-            httpGet:
-              path: /prestop
-              port: 8090
-              scheme: HTTP
-        name: mlserver-adapter
-        resources:
-          limits:
-            cpu: "2"
-            memory: 512Mi
-          requests:
-            cpu: 50m
-            memory: 96Mi
-        securityContext:
-          capabilities:
-            drop:
-            - ALL
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /models
-          name: models-dir
-        - mountPath: /storage-config
-          name: storage-config
-          readOnly: true
-      - env:
-        - name: REST_PROXY_LISTEN_PORT
-          value: "8008"
-        - name: REST_PROXY_GRPC_PORT
-          value: "1234"
-        - name: REST_PROXY_USE_TLS
-          value: "false"
-        - name: REST_PROXY_GRPC_MAX_MSG_SIZE_BYTES
-          value: "16777216"
-        image: kserve/rest-proxy:latest
-        imagePullPolicy: Always
-        name: rest-proxy
-        ports:
-        - containerPort: 8008
-          name: http
-          protocol: TCP
-        resources:
-          limits:
-            cpu: "1"
-            memory: 512Mi
-          requests:
-            cpu: 50m
-            memory: 96Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -559,6 +290,120 @@ spec:
                 values:
                 - amd64
       containers:
+      - env:
+        - name: REST_PROXY_LISTEN_PORT
+          value: "8008"
+        - name: REST_PROXY_GRPC_PORT
+          value: "1234"
+        - name: REST_PROXY_USE_TLS
+          value: "false"
+        - name: REST_PROXY_GRPC_MAX_MSG_SIZE_BYTES
+          value: "16777216"
+        image: kserve/rest-proxy:latest
+        imagePullPolicy: Always
+        name: rest-proxy
+        ports:
+        - containerPort: 8008
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            cpu: "1"
+            memory: 512Mi
+          requests:
+            cpu: 50m
+            memory: 96Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      - env:
+        - name: MLSERVER_MODELS_DIR
+          value: /models/_mlserver_models/
+        - name: MLSERVER_GRPC_PORT
+          value: "8001"
+        - name: MLSERVER_HTTP_PORT
+          value: "8002"
+        - name: MLSERVER_LOAD_MODELS_AT_STARTUP
+          value: "false"
+        - name: MLSERVER_MODEL_NAME
+          value: dummy-model-fixme
+        - name: MLSERVER_HOST
+          value: 127.0.0.1
+        - name: MLSERVER_GRPC_MAX_MESSAGE_LENGTH
+          value: "-1"
+        image: mlserver-0:replace
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            httpGet:
+              path: /prestop
+              port: 8090
+              scheme: HTTP
+        name: mlserver
+        resources:
+          limits:
+            cpu: "5"
+            memory: 1Gi
+          requests:
+            cpu: 500m
+            memory: 1Gi
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /models
+          name: models-dir
+      - command:
+        - /opt/app/mlserver-adapter
+        env:
+        - name: ADAPTER_PORT
+          value: "8085"
+        - name: RUNTIME_PORT
+          value: "8001"
+        - name: CONTAINER_MEM_REQ_BYTES
+          valueFrom:
+            resourceFieldRef:
+              containerName: mlserver
+              divisor: "0"
+              resource: requests.memory
+        - name: MEM_BUFFER_BYTES
+          value: "134217728"
+        - name: LOADTIME_TIMEOUT
+          value: "90000"
+        - name: USE_EMBEDDED_PULLER
+          value: "true"
+        - name: RUNTIME_VERSION
+          value: replace
+        image: image:tag
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            httpGet:
+              path: /prestop
+              port: 8090
+              scheme: HTTP
+        name: mlserver-adapter
+        resources:
+          limits:
+            cpu: "2"
+            memory: 512Mi
+          requests:
+            cpu: 50m
+            memory: 96Mi
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /models
+          name: models-dir
+        - mountPath: /storage-config
+          name: storage-config
+          readOnly: true
       - env:
         - name: MM_SERVICE_NAME
           value: modelmesh-serving
@@ -653,120 +498,6 @@ spec:
         - mountPath: /opt/kserve/mmesh/etcd
           name: etcd-config
           readOnly: true
-      - env:
-        - name: MLSERVER_MODELS_DIR
-          value: /models/_mlserver_models/
-        - name: MLSERVER_GRPC_PORT
-          value: "8001"
-        - name: MLSERVER_HTTP_PORT
-          value: "8002"
-        - name: MLSERVER_LOAD_MODELS_AT_STARTUP
-          value: "false"
-        - name: MLSERVER_MODEL_NAME
-          value: dummy-model-fixme
-        - name: MLSERVER_HOST
-          value: 127.0.0.1
-        - name: MLSERVER_GRPC_MAX_MESSAGE_LENGTH
-          value: "-1"
-        image: mlserver-0:replace
-        imagePullPolicy: IfNotPresent
-        lifecycle:
-          preStop:
-            httpGet:
-              path: /prestop
-              port: 8090
-              scheme: HTTP
-        name: mlserver
-        resources:
-          limits:
-            cpu: "5"
-            memory: 1Gi
-          requests:
-            cpu: 500m
-            memory: 1Gi
-        securityContext:
-          capabilities:
-            drop:
-            - ALL
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /models
-          name: models-dir
-      - command:
-        - /opt/app/mlserver-adapter
-        env:
-        - name: ADAPTER_PORT
-          value: "8085"
-        - name: RUNTIME_PORT
-          value: "8001"
-        - name: CONTAINER_MEM_REQ_BYTES
-          valueFrom:
-            resourceFieldRef:
-              containerName: mlserver
-              divisor: "0"
-              resource: requests.memory
-        - name: MEM_BUFFER_BYTES
-          value: "134217728"
-        - name: LOADTIME_TIMEOUT
-          value: "90000"
-        - name: USE_EMBEDDED_PULLER
-          value: "true"
-        - name: RUNTIME_VERSION
-          value: replace
-        image: image:tag
-        imagePullPolicy: IfNotPresent
-        lifecycle:
-          preStop:
-            httpGet:
-              path: /prestop
-              port: 8090
-              scheme: HTTP
-        name: mlserver-adapter
-        resources:
-          limits:
-            cpu: "2"
-            memory: 512Mi
-          requests:
-            cpu: 50m
-            memory: 96Mi
-        securityContext:
-          capabilities:
-            drop:
-            - ALL
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /models
-          name: models-dir
-        - mountPath: /storage-config
-          name: storage-config
-          readOnly: true
-      - env:
-        - name: REST_PROXY_LISTEN_PORT
-          value: "8008"
-        - name: REST_PROXY_GRPC_PORT
-          value: "1234"
-        - name: REST_PROXY_USE_TLS
-          value: "false"
-        - name: REST_PROXY_GRPC_MAX_MSG_SIZE_BYTES
-          value: "16777216"
-        image: kserve/rest-proxy:latest
-        imagePullPolicy: Always
-        name: rest-proxy
-        ports:
-        - containerPort: 8008
-          name: http
-          protocol: TCP
-        resources:
-          limits:
-            cpu: "1"
-            memory: 512Mi
-          requests:
-            cpu: 50m
-            memory: 96Mi
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -828,6 +559,95 @@ spec:
                 values:
                 - amd64
       containers:
+      - command:
+        - /opt/app/mlserver-adapter
+        env:
+        - name: ADAPTER_PORT
+          value: "8085"
+        - name: RUNTIME_PORT
+          value: "8001"
+        - name: CONTAINER_MEM_REQ_BYTES
+          valueFrom:
+            resourceFieldRef:
+              containerName: mlserver
+              divisor: "0"
+              resource: requests.memory
+        - name: MEM_BUFFER_BYTES
+          value: "134217728"
+        - name: LOADTIME_TIMEOUT
+          value: "90000"
+        - name: USE_EMBEDDED_PULLER
+          value: "true"
+        - name: RUNTIME_VERSION
+          value: replace
+        image: image:tag
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            httpGet:
+              path: /prestop
+              port: 8090
+              scheme: HTTP
+        name: mlserver-adapter
+        resources:
+          limits:
+            cpu: "2"
+            memory: 512Mi
+          requests:
+            cpu: 50m
+            memory: 96Mi
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /models
+          name: models-dir
+        - mountPath: /storage-config
+          name: storage-config
+          readOnly: true
+      - env:
+        - name: MLSERVER_MODELS_DIR
+          value: /models/_mlserver_models/
+        - name: MLSERVER_GRPC_PORT
+          value: "8001"
+        - name: MLSERVER_HTTP_PORT
+          value: "8002"
+        - name: MLSERVER_LOAD_MODELS_AT_STARTUP
+          value: "false"
+        - name: MLSERVER_MODEL_NAME
+          value: dummy-model-fixme
+        - name: MLSERVER_HOST
+          value: 127.0.0.1
+        - name: MLSERVER_GRPC_MAX_MESSAGE_LENGTH
+          value: "-1"
+        image: mlserver-0:replace
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            httpGet:
+              path: /prestop
+              port: 8090
+              scheme: HTTP
+        name: mlserver
+        resources:
+          limits:
+            cpu: "5"
+            memory: 1Gi
+          requests:
+            cpu: 500m
+            memory: 1Gi
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /models
+          name: models-dir
       - env:
         - name: MM_SERVICE_NAME
           value: modelmesh-serving
@@ -922,95 +742,6 @@ spec:
         - mountPath: /opt/kserve/mmesh/etcd
           name: etcd-config
           readOnly: true
-      - env:
-        - name: MLSERVER_MODELS_DIR
-          value: /models/_mlserver_models/
-        - name: MLSERVER_GRPC_PORT
-          value: "8001"
-        - name: MLSERVER_HTTP_PORT
-          value: "8002"
-        - name: MLSERVER_LOAD_MODELS_AT_STARTUP
-          value: "false"
-        - name: MLSERVER_MODEL_NAME
-          value: dummy-model-fixme
-        - name: MLSERVER_HOST
-          value: 127.0.0.1
-        - name: MLSERVER_GRPC_MAX_MESSAGE_LENGTH
-          value: "-1"
-        image: mlserver-0:replace
-        imagePullPolicy: IfNotPresent
-        lifecycle:
-          preStop:
-            httpGet:
-              path: /prestop
-              port: 8090
-              scheme: HTTP
-        name: mlserver
-        resources:
-          limits:
-            cpu: "5"
-            memory: 1Gi
-          requests:
-            cpu: 500m
-            memory: 1Gi
-        securityContext:
-          capabilities:
-            drop:
-            - ALL
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /models
-          name: models-dir
-      - command:
-        - /opt/app/mlserver-adapter
-        env:
-        - name: ADAPTER_PORT
-          value: "8085"
-        - name: RUNTIME_PORT
-          value: "8001"
-        - name: CONTAINER_MEM_REQ_BYTES
-          valueFrom:
-            resourceFieldRef:
-              containerName: mlserver
-              divisor: "0"
-              resource: requests.memory
-        - name: MEM_BUFFER_BYTES
-          value: "134217728"
-        - name: LOADTIME_TIMEOUT
-          value: "90000"
-        - name: USE_EMBEDDED_PULLER
-          value: "true"
-        - name: RUNTIME_VERSION
-          value: replace
-        image: image:tag
-        imagePullPolicy: IfNotPresent
-        lifecycle:
-          preStop:
-            httpGet:
-              path: /prestop
-              port: 8090
-              scheme: HTTP
-        name: mlserver-adapter
-        resources:
-          limits:
-            cpu: "2"
-            memory: 512Mi
-          requests:
-            cpu: 50m
-            memory: 96Mi
-        securityContext:
-          capabilities:
-            drop:
-            - ALL
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /models
-          name: models-dir
-        - mountPath: /storage-config
-          name: storage-config
-          readOnly: true
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -1072,6 +803,87 @@ spec:
                 values:
                 - amd64
       containers:
+      - command:
+        - /opt/app/ovms-adapter
+        env:
+        - name: ADAPTER_PORT
+          value: "8085"
+        - name: RUNTIME_PORT
+          value: "8888"
+        - name: CONTAINER_MEM_REQ_BYTES
+          valueFrom:
+            resourceFieldRef:
+              containerName: ovms
+              divisor: "0"
+              resource: requests.memory
+        - name: MEM_BUFFER_BYTES
+          value: "134217728"
+        - name: LOADTIME_TIMEOUT
+          value: "90000"
+        - name: USE_EMBEDDED_PULLER
+          value: "true"
+        - name: RUNTIME_VERSION
+          value: replace
+        image: image:tag
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            httpGet:
+              path: /prestop
+              port: 8090
+              scheme: HTTP
+        name: ovms-adapter
+        resources:
+          limits:
+            cpu: "2"
+            memory: 512Mi
+          requests:
+            cpu: 50m
+            memory: 96Mi
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /models
+          name: models-dir
+        - mountPath: /storage-config
+          name: storage-config
+          readOnly: true
+      - args:
+        - --port=8001
+        - --rest_port=8888
+        - --config_path=/models/model_config_list.json
+        - --file_system_poll_wait_seconds=0
+        - --grpc_bind_address=127.0.0.1
+        - --rest_bind_address=127.0.0.1
+        image: ovms-1:replace
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            httpGet:
+              path: /prestop
+              port: 8090
+              scheme: HTTP
+        name: ovms
+        resources:
+          limits:
+            cpu: "5"
+            memory: 1Gi
+          requests:
+            cpu: 500m
+            memory: 1Gi
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /models
+          name: models-dir
       - env:
         - name: MM_SERVICE_NAME
           value: modelmesh-serving
@@ -1166,87 +978,6 @@ spec:
         - mountPath: /opt/kserve/mmesh/etcd
           name: etcd-config
           readOnly: true
-      - args:
-        - --port=8001
-        - --rest_port=8888
-        - --config_path=/models/model_config_list.json
-        - --file_system_poll_wait_seconds=0
-        - --grpc_bind_address=127.0.0.1
-        - --rest_bind_address=127.0.0.1
-        image: ovms-1:replace
-        imagePullPolicy: IfNotPresent
-        lifecycle:
-          preStop:
-            httpGet:
-              path: /prestop
-              port: 8090
-              scheme: HTTP
-        name: ovms
-        resources:
-          limits:
-            cpu: "5"
-            memory: 1Gi
-          requests:
-            cpu: 500m
-            memory: 1Gi
-        securityContext:
-          capabilities:
-            drop:
-            - ALL
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /models
-          name: models-dir
-      - command:
-        - /opt/app/ovms-adapter
-        env:
-        - name: ADAPTER_PORT
-          value: "8085"
-        - name: RUNTIME_PORT
-          value: "8888"
-        - name: CONTAINER_MEM_REQ_BYTES
-          valueFrom:
-            resourceFieldRef:
-              containerName: ovms
-              divisor: "0"
-              resource: requests.memory
-        - name: MEM_BUFFER_BYTES
-          value: "134217728"
-        - name: LOADTIME_TIMEOUT
-          value: "90000"
-        - name: USE_EMBEDDED_PULLER
-          value: "true"
-        - name: RUNTIME_VERSION
-          value: replace
-        image: image:tag
-        imagePullPolicy: IfNotPresent
-        lifecycle:
-          preStop:
-            httpGet:
-              path: /prestop
-              port: 8090
-              scheme: HTTP
-        name: ovms-adapter
-        resources:
-          limits:
-            cpu: "2"
-            memory: 512Mi
-          requests:
-            cpu: 50m
-            memory: 96Mi
-        securityContext:
-          capabilities:
-            drop:
-            - ALL
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /models
-          name: models-dir
-        - mountPath: /storage-config
-          name: storage-config
-          readOnly: true
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -1308,6 +1039,105 @@ spec:
                 values:
                 - amd64
       containers:
+      - command:
+        - /opt/app/triton-adapter
+        env:
+        - name: ADAPTER_PORT
+          value: "8085"
+        - name: RUNTIME_PORT
+          value: "8001"
+        - name: CONTAINER_MEM_REQ_BYTES
+          valueFrom:
+            resourceFieldRef:
+              containerName: triton
+              divisor: "0"
+              resource: requests.memory
+        - name: MEM_BUFFER_BYTES
+          value: "134217728"
+        - name: LOADTIME_TIMEOUT
+          value: "90000"
+        - name: USE_EMBEDDED_PULLER
+          value: "true"
+        - name: RUNTIME_VERSION
+          value: replace
+        - name: LOADING_CONCURRENCY
+          value: "2"
+        image: image:tag
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            httpGet:
+              path: /prestop
+              port: 8090
+              scheme: HTTP
+        name: triton-adapter
+        resources:
+          limits:
+            cpu: "2"
+            memory: 512Mi
+          requests:
+            cpu: 50m
+            memory: 96Mi
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /models
+          name: models-dir
+        - mountPath: /storage-config
+          name: storage-config
+          readOnly: true
+      - args:
+        - -c
+        - 'mkdir -p /models/_triton_models; chmod 777 /models/_triton_models; exec
+          tritonserver "--model-repository=/models/_triton_models" "--model-control-mode=explicit"
+          "--strict-model-config=false" "--strict-readiness=false" "--allow-http=true"
+          "--allow-sagemaker=false" '
+        command:
+        - /bin/sh
+        image: tritonserver-2:replace
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            httpGet:
+              path: /prestop
+              port: 8090
+              scheme: HTTP
+        livenessProbe:
+          exec:
+            command:
+            - curl
+            - --fail
+            - --silent
+            - --show-error
+            - --max-time
+            - "9"
+            - http://localhost:8000/v2/health/live
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 10
+        name: triton
+        resources:
+          limits:
+            cpu: "5"
+            memory: 1Gi
+          requests:
+            cpu: 500m
+            memory: 1Gi
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /models
+          name: models-dir
       - env:
         - name: MM_SERVICE_NAME
           value: modelmesh-serving
@@ -1402,105 +1232,6 @@ spec:
         - mountPath: /opt/kserve/mmesh/etcd
           name: etcd-config
           readOnly: true
-      - args:
-        - -c
-        - 'mkdir -p /models/_triton_models; chmod 777 /models/_triton_models; exec
-          tritonserver "--model-repository=/models/_triton_models" "--model-control-mode=explicit"
-          "--strict-model-config=false" "--strict-readiness=false" "--allow-http=true"
-          "--allow-sagemaker=false" '
-        command:
-        - /bin/sh
-        image: tritonserver-2:replace
-        imagePullPolicy: IfNotPresent
-        lifecycle:
-          preStop:
-            httpGet:
-              path: /prestop
-              port: 8090
-              scheme: HTTP
-        livenessProbe:
-          exec:
-            command:
-            - curl
-            - --fail
-            - --silent
-            - --show-error
-            - --max-time
-            - "9"
-            - http://localhost:8000/v2/health/live
-          failureThreshold: 3
-          initialDelaySeconds: 5
-          periodSeconds: 30
-          successThreshold: 1
-          timeoutSeconds: 10
-        name: triton
-        resources:
-          limits:
-            cpu: "5"
-            memory: 1Gi
-          requests:
-            cpu: 500m
-            memory: 1Gi
-        securityContext:
-          capabilities:
-            drop:
-            - ALL
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /models
-          name: models-dir
-      - command:
-        - /opt/app/triton-adapter
-        env:
-        - name: ADAPTER_PORT
-          value: "8085"
-        - name: RUNTIME_PORT
-          value: "8001"
-        - name: CONTAINER_MEM_REQ_BYTES
-          valueFrom:
-            resourceFieldRef:
-              containerName: triton
-              divisor: "0"
-              resource: requests.memory
-        - name: MEM_BUFFER_BYTES
-          value: "134217728"
-        - name: LOADTIME_TIMEOUT
-          value: "90000"
-        - name: USE_EMBEDDED_PULLER
-          value: "true"
-        - name: RUNTIME_VERSION
-          value: replace
-        - name: LOADING_CONCURRENCY
-          value: "2"
-        image: image:tag
-        imagePullPolicy: IfNotPresent
-        lifecycle:
-          preStop:
-            httpGet:
-              path: /prestop
-              port: 8090
-              scheme: HTTP
-        name: triton-adapter
-        resources:
-          limits:
-            cpu: "2"
-            memory: 512Mi
-          requests:
-            cpu: 50m
-            memory: 96Mi
-        securityContext:
-          capabilities:
-            drop:
-            - ALL
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /models
-          name: models-dir
-        - mountPath: /storage-config
-          name: storage-config
-          readOnly: true
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -1562,6 +1293,40 @@ spec:
                 values:
                 - amd64
       containers:
+      - env:
+        - name: MODEL_DIRECTORY_PATH
+          value: /models
+        - name: MODEL_SERVER_MEM_REQ_BYTES
+          valueFrom:
+            resourceFieldRef:
+              containerName: modelserver
+              divisor: "0"
+              resource: requests.memory
+        image: seldonio/mlserver:0.3.2
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            httpGet:
+              path: /prestop
+              port: 8090
+              scheme: HTTP
+        name: modelserver
+        resources:
+          limits:
+            cpu: "5"
+            memory: 1Gi
+          requests:
+            cpu: 500m
+            memory: 1Gi
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /models
+          name: models-dir
       - env:
         - name: MM_SERVICE_NAME
           value: modelmesh-serving
@@ -1656,40 +1421,6 @@ spec:
         - mountPath: /opt/kserve/mmesh/etcd
           name: etcd-config
           readOnly: true
-      - env:
-        - name: MODEL_DIRECTORY_PATH
-          value: /models
-        - name: MODEL_SERVER_MEM_REQ_BYTES
-          valueFrom:
-            resourceFieldRef:
-              containerName: modelserver
-              divisor: "0"
-              resource: requests.memory
-        image: seldonio/mlserver:0.3.2
-        imagePullPolicy: IfNotPresent
-        lifecycle:
-          preStop:
-            httpGet:
-              path: /prestop
-              port: 8090
-              scheme: HTTP
-        name: modelserver
-        resources:
-          limits:
-            cpu: "5"
-            memory: 1Gi
-          requests:
-            cpu: 500m
-            memory: 1Gi
-        securityContext:
-          capabilities:
-            drop:
-            - ALL
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /models
-          name: models-dir
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler


### PR DESCRIPTION
#### Motivation

Kubernetes starts containers sequentially in order, which can mean the start of later containers is held up if their images have to be pulled. For large model server images this can cause a problem because model-mesh waits for a limited amount of time at startup for the runtime to become ready before returning ready from its own probe.

Making the `mm` container last in the list ensures that no image pulling time will be included in this startup polling time and avoids unnecessary timeouts / extended readiness probe failures.

#### Modifications

- Add `ensureMMContainerIsLast` function to runtime deployment reconciliation logic which runs after other modifications to the pod spec.
- Update unit test fixtures accordingly

#### Result

More stable deployments in cases where the model server image takes a long time to pull.

Signed-off-by: Nick Hill <nickhill@us.ibm.com>