### PR TITLE
Change PreStop handler to use exec so it can reach the endpoint on localhost

### DIFF
--- a/controllers/modelmesh/runtime.go
+++ b/controllers/modelmesh/runtime.go
@@ -104,9 +104,8 @@ func (m *Deployment) addRuntimeToDeployment(deployment *appsv1.Deployment) error
 	// first prepare the common variables needed for both adapter and other containers
 	lifecycle := &corev1.Lifecycle{
 		PreStop: &corev1.Handler{
-			HTTPGet: &corev1.HTTPGetAction{
-				Path: "/prestop",
-				Port: intstr.FromInt(8090),
+			Exec: &corev1.ExecAction{
+				Command: []string{"curl", "http://localhost:8090"},
 			},
 		},
 	}


### PR DESCRIPTION
#### Motivation/modifications/result

Changes the lifecycle hook to use an exec action instead of httpGet so it can read `/prestop` when the server only listens on localhost.

See also https://github.com/kserve/modelmesh/pull/52