### PR TITLE
feat: Make list of supported built-in runtime server types overridable

### DIFF
--- a/config/default/config-defaults.yaml
+++ b/config/default/config-defaults.yaml
@@ -51,3 +51,7 @@ storageHelperResources:
 serviceAccountName: ""
 metrics:
   enabled: true
+builtInServerTypes:
+  - triton
+  - mlserver
+  - ovms

--- a/controllers/servingruntime_controller.go
+++ b/controllers/servingruntime_controller.go
@@ -85,10 +85,6 @@ type runtimeInfo struct {
 	TimeTransitionedToNoPredictors *time.Time
 }
 
-var builtInServerTypes = map[kserveapi.ServerType]interface{}{
-	kserveapi.MLServer: nil, kserveapi.Triton: nil, kserveapi.OVMS: nil,
-}
-
 // +kubebuilder:rbac:groups=serving.kserve.io,resources=servingruntimes;servingruntimes/finalizers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=serving.kserve.io,resources=servingruntimes/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=apps,resources=deployments;deployments/finalizers,verbs=get;list;watch;create;update;patch;delete
@@ -188,7 +184,7 @@ func (r *ServingRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	// Check that ServerType is provided in rt.Spec and that this value matches that of the specified container
-	if err = validateServingRuntimeSpec(rt); err != nil {
+	if err = validateServingRuntimeSpec(rt, cfg); err != nil {
 		return ctrl.Result{}, fmt.Errorf("Invalid ServingRuntime Spec: %w", err)
 	}
 

--- a/controllers/servingruntime_validator_test.go
+++ b/controllers/servingruntime_validator_test.go
@@ -310,8 +310,12 @@ func TestValidateServingRuntimeSpec(t *testing.T) {
 			expectError: true,
 		},
 	} {
+		cfg, err := getDefaultConfig()
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateServingRuntimeSpec(tt.servingRuntime)
+			err := validateServingRuntimeSpec(tt.servingRuntime, cfg)
 
 			if tt.expectError && err == nil {
 				t.Errorf("Expected an error, but didn't get one")

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -206,15 +206,19 @@ var _ = AfterEach(func() {
 
 var defaultTestConfigFileContents []byte
 
-func resetReconcilerConfig() {
+func getDefaultConfig() (*config2.Config, error) {
 	if defaultTestConfigFileContents == nil {
 		var err error
 		var testConfigFile = "./testdata/test-config-defaults.yaml"
-		defaultTestConfigFileContents, err = ioutil.ReadFile(testConfigFile)
-		Expect(err).ToNot(HaveOccurred())
+		if defaultTestConfigFileContents, err = ioutil.ReadFile(testConfigFile); err != nil {
+			return nil, err
+		}
 	}
+	return config2.NewMergedConfigFromString(string(defaultTestConfigFileContents))
+}
 
-	config, err := config2.NewMergedConfigFromString(string(defaultTestConfigFileContents))
+func resetReconcilerConfig() {
+	config, err := getDefaultConfig()
 	Expect(err).ToNot(HaveOccurred())
 
 	// re-assign the reference to the config

--- a/fvt/tls.go
+++ b/fvt/tls.go
@@ -110,7 +110,7 @@ func (g *CertGenerator) generate() error {
 	}
 
 	if err = pem.Encode(g.PrivateKeyPEM, &pem.Block{
-		Type:  "RSA PRIVATE KEY",
+		Type:  "PRIVATE KEY",
 		Bytes: privBytes,
 	}); err != nil {
 		return err

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,6 +24,8 @@ import (
 	"sync/atomic"
 	"unsafe"
 
+	kserveapi "github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -72,6 +74,7 @@ type Config struct {
 	PodsPerRuntime         uint16
 	StorageSecretName      string
 	EnableAccessLogging    bool
+	BuiltInServerTypes     []string
 
 	ServiceAccountName string
 
@@ -335,6 +338,9 @@ func defaults(v *viper.Viper) {
 	v.SetDefault(concatStringsWithDelimiter([]string{"ScaleToZero", "GracePeriodSeconds"}), 60)
 	// default size 16MiB in bytes
 	v.SetDefault("GrpcMaxMessageSizeBytes", 16777216)
+	v.SetDefault("BuiltInServerTypes", []string{
+		string(kserveapi.MLServer), string(kserveapi.Triton), string(kserveapi.OVMS),
+	})
 }
 
 func concatStringsWithDelimiter(elems []string) string {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -14,6 +14,7 @@
 package config
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -192,6 +193,26 @@ grpcMaxMessageSizeBytes: 33554432`
 	//Verify system config map default
 	if conf.GrpcMaxMessageSizeBytes != expectedGrpcMessageSize {
 		t.Fatalf("Expected GrpcMaxMessageSizeBytes=%v but found %v", expectedGrpcMessageSize, conf.GrpcMaxMessageSizeBytes)
+	}
+}
+
+func TestBuiltInServerTypes(t *testing.T) {
+	yaml := `
+builtInServerTypes:
+ - triton
+ - mlserver
+ - ovms
+ - a_new_one`
+
+	expectedTypes := []string{"triton", "mlserver", "ovms", "a_new_one"}
+
+	conf, err := NewMergedConfigFromString(yaml)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(expectedTypes, conf.BuiltInServerTypes) {
+		t.Fatalf("Expected BuiltInServerTypes=%v but found %v", expectedTypes, conf.BuiltInServerTypes)
 	}
 }
 


### PR DESCRIPTION
#### Motivation

Model-mesh serving makes use of a single adapter image to interface with a number of "built-in" model server types, currently comprising `triton`, `mlserver`, `ovms`.

Currently which kind of adapter to run is controlled by the entrypoint to the adapter container within the modelmesh pods, which is set by the controller based on the `builtInAdapter.serverType` field of the `ServingRuntime` CRD.

However this is currently validated against a hardcoded list of type strings meaning that any extensions to the runtime adapter image to support new kinds of model servers also require a code change and rebuild of the controller image.

#### Modifications

Move the list of supported built-in server types to a list in the global config.
Update controller validation logic and tests accordingly.

#### Result

The shared built-in runtime adapter can be extended to support new runtime types without requiring a code change to the controller.