### PR TITLE
feat: Pass ServingRuntime inference endpoint to built-in adapter

### DIFF
--- a/controllers/modelmesh/runtime.go
+++ b/controllers/modelmesh/runtime.go
@@ -246,7 +246,7 @@ func (m *Deployment) addRuntimeToDeployment(deployment *appsv1.Deployment) error
 				Value: runtimeVersion,
 			},
 			{}, {}, {}, {}, // allocate larger array to avoid reallocation
-		}[:7]
+		}[:8]
 
 		if mlc, ok := rt.Annotations["maxLoadingConcurrency"]; ok {
 			builtInAdapterContainer.Env = append(builtInAdapterContainer.Env, corev1.EnvVar{

--- a/controllers/testdata/servingruntime_controller.golden
+++ b/controllers/testdata/servingruntime_controller.golden
@@ -50,6 +50,8 @@ spec:
           value: "8085"
         - name: RUNTIME_PORT
           value: "8001"
+        - name: RUNTIME_DATA_ENDPOINT
+          value: port:8001
         - name: CONTAINER_MEM_REQ_BYTES
           valueFrom:
             resourceFieldRef:
@@ -362,6 +364,8 @@ spec:
           value: "8085"
         - name: RUNTIME_PORT
           value: "8001"
+        - name: RUNTIME_DATA_ENDPOINT
+          value: port:8001
         - name: CONTAINER_MEM_REQ_BYTES
           valueFrom:
             resourceFieldRef:
@@ -566,6 +570,8 @@ spec:
           value: "8085"
         - name: RUNTIME_PORT
           value: "8001"
+        - name: RUNTIME_DATA_ENDPOINT
+          value: port:8001
         - name: CONTAINER_MEM_REQ_BYTES
           valueFrom:
             resourceFieldRef:
@@ -810,6 +816,8 @@ spec:
           value: "8085"
         - name: RUNTIME_PORT
           value: "8888"
+        - name: RUNTIME_DATA_ENDPOINT
+          value: port:8001
         - name: CONTAINER_MEM_REQ_BYTES
           valueFrom:
             resourceFieldRef:
@@ -1046,6 +1054,8 @@ spec:
           value: "8085"
         - name: RUNTIME_PORT
           value: "8001"
+        - name: RUNTIME_DATA_ENDPOINT
+          value: port:8001
         - name: CONTAINER_MEM_REQ_BYTES
           valueFrom:
             resourceFieldRef:


### PR DESCRIPTION
#### Motivation

It may be useful for some built-in runtime adapters to have the model server's inferencing endpoint information in addition to the existing "management" port number that's passed (in case it is different).

#### Modifications

- Set a new `RUNTIME_DATA_ENDPOINT` env var on the built-in adapter container
- Parse the `ADAPTER_PORT` env var value from the ServingRuntime `grpcEndpoint` field instead of hardcoding to 8085
