### PR TITLE
doc: fix port-forward command in run-inference.md

### DIFF
--- a/docs/predictors/run-inference.md
+++ b/docs/predictors/run-inference.md
@@ -77,7 +77,7 @@ However, the max number of bytes for the GRPC request payloads depends on both t
 Using [`kubectl port-forward`](https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/):
 
 ```shell
-kubectl port-forward modelmesh-serving 8033:8033
+kubectl port-forward service/modelmesh-serving 8033:8033
 ```
 
 This assumes you are using port 8033, change the source and/or destination ports as appropriate.
@@ -169,7 +169,7 @@ By default, REST requests will go through the `modelmesh-serving` service using 
 Since the service is also headless by default, you can access this service by using [`kubectl port-forward`](https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/):
 
 ```shell
-kubectl port-forward modelmesh-serving 8008:8008
+kubectl port-forward service/modelmesh-serving 8008:8008
 ```
 
 This assumes you are using port 8008 for REST. Change the source and/or destination ports as appropriate.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -190,7 +190,7 @@ since a normal Service has issues load balancing gRPC requests. See more info
 To test out **gRPC** inference requests, you can port-forward the headless service _in a separate terminal window_:
 
 ```shell
-kubectl port-forward --address 0.0.0.0 service/modelmesh-serving  8033 -n modelmesh-serving
+kubectl port-forward --address 0.0.0.0 service/modelmesh-serving 8033 -n modelmesh-serving
 ```
 
 Then a gRPC client generated from the KServe [grpc_predict_v2.proto](https://github.com/kserve/kserve/blob/master/docs/predict-api/v2/grpc_predict_v2.proto)


### PR DESCRIPTION
#### Motivation

The code snippet to `port-forward` the `modelmesh-serving` service did not work:

```Bash
$ kubectl port-forward modelmesh-serving 8033:8033

Error from server (NotFound): pods "modelmesh-serving" not found
```

#### Modifications

Update the code snippet to specify the resource type `service`:

```Bash
$ kubectl port-forward service/modelmesh-serving 8033:8033
```


#### Result


```
Forwarding from 127.0.0.1:8033 -> 8033
Forwarding from [::1]:8033 -> 8033
Handling connection for 8033

```

/cc @njhill 
/cc @chinhuang007 