### PR TITLE
fix: Tolerate kustomize version 3.2

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,7 +5,7 @@ To quickly get started using ModelMesh Serving, here is a brief guide.
 ## Prerequisites
 
 - A Kubernetes cluster v 1.16+ with cluster administrative privileges
-- [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) and [kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/) (v4.0.0+)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) and [kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/) (v3.2.0+)
 - At least 4 vCPU and 8 GB memory. For more details, please see [here](install/environment.md#deployed-components).
 
 ## 1. Install ModelMesh Serving

--- a/scripts/delete.sh
+++ b/scripts/delete.sh
@@ -95,11 +95,11 @@ popd
 
 # Older versions of kustomize have different load restrictor flag formats.
 # Can be removed once Kubeflow installation stops requiring v3.2.
-kustomize_version=$(kustomize version | awk -F'kustomize/' '{print $2}')
+kustomize_version=$(kustomize version --short | grep -o -E "[0-9]\.[0-9]\.[0-9]")
 kustomize_load_restrictor_arg="--load-restrictor LoadRestrictionsNone"
-if [[ -n "$kustomize_version" && "$kustomize_version" < "v3.4.0" ]]; then
+if [[ -n "$kustomize_version" && "$kustomize_version" < "3.4.0" ]]; then
     kustomize_load_restrictor_arg="--load_restrictor none"
-elif [[ -n "$kustomize_version" && "$kustomize_version" < "v4.0.1" ]]; then
+elif [[ -n "$kustomize_version" && "$kustomize_version" < "4.0.1" ]]; then
     kustomize_load_restrictor_arg="--load_restrictor LoadRestrictionsNone"
 fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -303,11 +303,11 @@ wait_for_pods_ready "-l control-plane=modelmesh-controller"
 
 # Older versions of kustomize have different load restrictor flag formats.
 # Can be removed once Kubeflow installation stops requiring v3.2.
-kustomize_version=$(kustomize version | awk -F'kustomize/' '{print $2}')
+kustomize_version=$(kustomize version --short | grep -o -E "[0-9]\.[0-9]\.[0-9]")
 kustomize_load_restrictor_arg="--load-restrictor LoadRestrictionsNone"
-if [[ -n "$kustomize_version" && "$kustomize_version" < "v3.4.0" ]]; then
+if [[ -n "$kustomize_version" && "$kustomize_version" < "3.4.0" ]]; then
     kustomize_load_restrictor_arg="--load_restrictor none"
-elif [[ -n "$kustomize_version" && "$kustomize_version" < "v4.0.1" ]]; then
+elif [[ -n "$kustomize_version" && "$kustomize_version" < "4.0.1" ]]; then
     kustomize_load_restrictor_arg="--load_restrictor LoadRestrictionsNone"
 fi
 

--- a/scripts/setup_user_namespaces.sh
+++ b/scripts/setup_user_namespaces.sh
@@ -72,11 +72,11 @@ if [[ ! -z $user_ns_array ]]; then
 
     # Older versions of kustomize have different load restrictor flag formats.
     # Can be removed once Kubeflow installation stops requiring v3.2.
-    kustomize_version=$(kustomize version | awk -F'kustomize/' '{print $2}')
+    kustomize_version=$(kustomize version --short | grep -o -E "[0-9]\.[0-9]\.[0-9]")
     kustomize_load_restrictor_arg="--load-restrictor LoadRestrictionsNone"
-    if [[ -n "$kustomize_version" && "$kustomize_version" < "v3.4.0" ]]; then
+    if [[ -n "$kustomize_version" && "$kustomize_version" < "3.4.0" ]]; then
         kustomize_load_restrictor_arg="--load_restrictor none"
-    elif [[ -n "$kustomize_version" && "$kustomize_version" < "v4.0.1" ]]; then
+    elif [[ -n "$kustomize_version" && "$kustomize_version" < "4.0.1" ]]; then
         kustomize_load_restrictor_arg="--load_restrictor LoadRestrictionsNone"
     fi
 


### PR DESCRIPTION
#### Motivation

Developers who work on both Kubeflow and ModelMesh must use different versions of the `kustomize` CLI as Kubeflow installation requires version no greater than `3.2.0` yet ModelMesh installation requires a version greater than `4.0.0`.

There have been previous changes to the install scripts attempting to tolerate older `kustomize` versions, yet for `3.2` it is still causing errors like these:

```
...
Installing ModelMesh Serving built-in runtimes
Error: unknown flag: --load-restrictor
error: no objects passed to apply
```

This is because various versions of `kustomize` produce differently formatted output and the ModelMesh install scripts do not capture the intended semantic version identifier, i.e.

```Bash
$ kustomize version  # 3.2

Version: {KustomizeVersion:3.2.0 GitCommit:a3103f1e62ddb5b696daa3fd359bb6f2e8333b49 BuildDate:2019-09-18T16:26:36Z GoOs:darwin GoArch:amd64}

$ kustomize version | awk -F'kustomize/' '{print $2}'


# notice nothing here
```

```Bash
$ kustomize version  # 3.4

{Version:kustomize/v3.4.0 GitCommit:2c9635967a2b1469d605a91a1d040bd27c73ca7d BuildDate:2019-11-12T05:00:57Z GoOs:darwin GoArch:amd64}

$ kustomize version | awk -F'kustomize/' '{print $2}'

v3.4.0 GitCommit:2c9635967a2b1469d605a91a1d040bd27c73ca7d BuildDate:2019-11-12T05:00:57Z GoOs:darwin GoArch:amd64}

```

#### Modifications

Change the install (and delete) scripts to `grep` only the semantic version and use that to choose the correct install command syntax.

#### Result

Installation (and de-installation) works for `kustomize` versions `3.2.0` up to latest (currently `4.5.7`)

#### Related Issues:

Fixes #66