### PR TITLE
chore: Preserve command history from `make develop` sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # general
 .env
-.bash_history
 
 public/
 target/
@@ -30,5 +29,7 @@ bin
 .vscode
 *~
 
+# Modelmesh development related artifacts
 devbuild
 .develop_image_name
+.bash_history

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -59,8 +59,8 @@ touch .bash_history
 
 declare -a docker_run_args=(
   -v "${PWD}:/workspace"
-  -v "${PWD}/.bash_history:/workspace/.bash_history"
-  -v /var/run/docker.sock:/var/run/docker.sock
+  -v "${PWD}/.bash_history:/root/.bash_history"
+  -v "/var/run/docker.sock:/var/run/docker.sock"
 )
 
 if [ "${CI}" != "true" ]; then


### PR DESCRIPTION
#### Motivation

When using the containerized development environment (`make develop`) to test changes to the ModelMesh source code or running FVT tests all command history is lost from session to session -- which negatively impacts productivity.

#### Modifications

The ModelMesh develop container runs as root and needs the command history file mounted under the `/root/` directory, not `/workspace/`

#### Result

The develop container command history is preserved from one `make develop` session to the next.

/cc @njhill @chinhuang007 