### PR TITLE
doc: Update cluster sizing link in quickstart.md

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,7 +6,7 @@ To quickly get started using ModelMesh Serving, here is a brief guide.
 
 - A Kubernetes cluster v 1.16+ with cluster administrative privileges
 - [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) and [kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/) (v4.0.0+)
-- At least 4 vCPU and 8 GB memory. For more details, please see [here](install/environment.md#deployed-components).
+- At least 4 vCPU and 8 GB memory. For more details, please see [here](install/README.md#deployed-components).
 
 ## 1. Install ModelMesh Serving
 


### PR DESCRIPTION
#### Motivation

There is a [dead link](https://github.com/kserve/modelmesh-serving/blob/main/docs/install/environment.md#deployed-components) in the **Prerequisites** section of the [Quickstart guide](https://github.com/kserve/modelmesh-serving/blob/main/docs/quickstart.md#prerequisites).

#### Modifications

Update to the correct link to the **"[Deployed Components](https://github.com/kserve/modelmesh-serving/blob/main/docs/install/README.md#deployed-components)"**.

#### Result

Link works again.

/cc @njhill @chinhuang007 