### PR TITLE
chore: Fix error in `verify_doc_links.py` script

### DIFF
--- a/scripts/verify_doc_links.py
+++ b/scripts/verify_doc_links.py
@@ -101,8 +101,7 @@ def get_links_from_md_file(md_file_path: str) -> [(int, str, str)]:  # -> [(line
 
         # find plain http(s)-style links
         for url in re.findall(r"[\n\r\s\"'](https?://[^\s]+)[\n\r\s\"']", line_text):
-            if not any(s in url for s in
-                       ["play.min.io", ":", "oauth2.googleapis.com"]):
+            if not any(s in url for s in ["play.min.io", "oauth2.googleapis.com"]):
                 try:
                     urlparse(url)
                     line_text_url.append((line_number + 1, "", url))


### PR DESCRIPTION
#### Motivation

In its current version the `verify_doc_links.py` script excludes any URLs that contain a colon `:` character.

This was meant to exclude any local URLs with a port like "`:8008`". Instead it excludes any URLs that start with "`http:`" or "`https:`". The "rookie" who created that script! 🙄 


#### Modifications

Remove the ":" from the list of patterns to identify URLs that should be excluded from the link verification.

#### Result

220 links found instead of 211 before.
