### PR TITLE
chore: Update to use latest OVMS 2022.2 image

### DIFF
--- a/config/runtimes/kustomization.yaml
+++ b/config/runtimes/kustomization.yaml
@@ -19,15 +19,15 @@ resources:
 images:
   - name: tritonserver-2
     newName: nvcr.io/nvidia/tritonserver
-    newTag: 21.06.1-py3
+    newTag: "21.06.1-py3"
 
   - name: mlserver-0
     newName: seldonio/mlserver
-    newTag: 0.5.2
+    newTag: "0.5.2"
 
   - name: ovms-1
     newName: openvino/model_server
-    newTag: "2022.1"
+    newTag: "2022.2"
 
 transformers:
   - ../default/metadataLabelTransformer.yaml


### PR DESCRIPTION
#### Motivation

Intel have released a new version of OpenVINO Model Server which now supports the KServe V2 prediction API (in addition to existing V1 API support): https://github.com/openvinotoolkit/model_server/releases/tag/v2022.2

#### Modifications

Update OVMS image tag from 2022.1 to 2022.2 in the ServingRuntime configuration.

#### Result

KServe V2 API can be used with OpenVINO Model Server and model-mesh.