### PR TITLE
docs: Fix TLS secret name ConfigMap update example

### DIFF
--- a/docs/configuration/tls.md
+++ b/docs/configuration/tls.md
@@ -56,7 +56,7 @@ For basic TLS, only the fields `tls.crt` and `tls.key` are needed in the kube se
 
 3.  Create a `Certificate` CR
 
-        oc apply -f - <<EOF
+        kubectl apply -f - <<EOF
         apiVersion: cert-manager.io/v1
         kind: Certificate
         metadata:
@@ -107,16 +107,17 @@ For basic TLS, only the fields `tls.crt` and `tls.key` are needed in the kube se
 
     **Example:**
 
-        kubectl apply -f - <<EOF
+        kubectl create -f - <<EOF
         apiVersion: v1
         kind: ConfigMap
         metadata:
           name: model-serving-config
         data:
           config.yaml: |
-            tls.secretName: ${SECRET_NAME}
+            tls:
+              secretName: ${SECRET_NAME}
         EOF
 
 6.  Retrieve the `ca.crt` (to be used in clients)
 
-        kubectl get secret ${SECRET_NAME} -o jsonpath="{.data.ca\.crt}"
+        kubectl get secret ${SECRET_NAME} -o jsonpath="{.data.ca\.crt}" > ca.crt


### PR DESCRIPTION
#### Motivation

The script snippet in our TLS docs for creating a configmap with the TLS secret name parameter included incorrect yaml which would not result in TLS being enabled. It should be:
```yaml
        data:
          config.yaml: |
            tls:
              secretName: ${SECRET_NAME}
```
instead of
```yaml
        data:
          config.yaml: |
            tls.secretName: ${SECRET_NAME}
```
#### Modification

- Fix the config yaml
- Change `kubectl apply` to `kubectl create` to avoid overwriting existing config
- Add `> ca.crt` to the cert retrieval command
- Replace `oc` with `kubectl` in Certificate CR example

#### Result

Correct docs.

Signed-off-by: Nick Hill <nickhill@us.ibm.com>