### PR TITLE
feat: Update makefile to support building with podman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ ifeq (run,$(firstword $(MAKECMDGOALS)))
   RUN_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
 endif
 
+# Container Engine to be used for building images
+ENGINE ?= "docker"
+
 # Image URL to use all building/pushing image targets
 IMG ?= kserve/modelmesh-controller:latest
 # Namespace to deploy model-serve into
@@ -111,11 +114,11 @@ generate: controller-gen
 
 # Build the final runtime docker image
 build:
-	./scripts/build_docker.sh --target runtime
+	./scripts/build_docker.sh --target runtime --engine $(ENGINE)
 
 # Build the develop docker image
 build.develop:
-	./scripts/build_devimage.sh
+	./scripts/build_devimage.sh $(ENGINE)
 
 # Start a terminal session in the develop docker container
 develop: build.develop

--- a/scripts/build_devimage.sh
+++ b/scripts/build_devimage.sh
@@ -19,6 +19,7 @@ set -euo pipefail
 CONTEXT_DIR=devbuild
 IMAGE_NAME=kserve/modelmesh-controller-develop
 DEV_DEPS="$0 Dockerfile.develop go.mod go.sum .pre-commit-config.yaml"
+ENGINE=${1:-docker}
 
 # command is shasum on osx
 SHASUM=sha1sum
@@ -27,18 +28,18 @@ DEV_IMG_TAG=$(cat $(ls ${DEV_DEPS}) | ${SHASUM} | head -c 16)
 
 FULL_IMAGE_NAME="${IMAGE_NAME}:${DEV_IMG_TAG}"
 echo "Pulling dev image ${FULL_IMAGE_NAME}..."
-if docker pull -q ${FULL_IMAGE_NAME}; then
+if $ENGINE pull -q ${FULL_IMAGE_NAME}; then
     echo "Successfully pulled dev image ${FULL_IMAGE_NAME}"
 else
   mkdir -p $CONTEXT_DIR
   cp ${DEV_DEPS} ${CONTEXT_DIR}
   echo "Building dev image ${FULL_IMAGE_NAME}"
-  docker build -f ${CONTEXT_DIR}/Dockerfile.develop -t ${FULL_IMAGE_NAME} ${CONTEXT_DIR}
+  $ENGINE build -f ${CONTEXT_DIR}/Dockerfile.develop -t ${FULL_IMAGE_NAME} ${CONTEXT_DIR}
 fi
 echo -n "${FULL_IMAGE_NAME}" > .develop_image_name
 
-NUM_LAYERS=$(docker images -q "${FULL_IMAGE_NAME}" | xargs docker history | egrep -v "^IMAGE" | wc -l | tr -d ' ')
+NUM_LAYERS=$($ENGINE images -q "${FULL_IMAGE_NAME}" | xargs $ENGINE history | egrep -v "^IMAGE" | wc -l | tr -d ' ')
 echo "Image ${FULL_IMAGE_NAME} has ${NUM_LAYERS} layers"
 
 echo "Tagging dev image ${FULL_IMAGE_NAME} as latest"
-docker tag ${FULL_IMAGE_NAME} "${IMAGE_NAME}:latest"
+$ENGINE tag ${FULL_IMAGE_NAME} "${IMAGE_NAME}:latest"

--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -22,6 +22,7 @@ usage: $0 [flags]
   [-t | --target]     Specify a target to build, default: "runtime"
   [--tag]             Docker Image Tag to use
   [--devimage]        Full name of dev docker image
+  [--engine]          Container Engine to be used, default: "docker"
 EOF
 )"
 
@@ -34,6 +35,7 @@ DOCKER_TARGET="runtime"
 DOCKER_TAG="$(git rev-parse --abbrev-ref HEAD)-$(date +"%Y%m%dT%H%M%S%Z")"
 CONTROLLER_IMG="kserve/modelmesh-controller"
 DEV_IMAGE="$(cat .develop_image_name)"
+ENGINE="docker"
 
 while (("$#")); do
   arg="$1"
@@ -62,6 +64,15 @@ while (("$#")); do
   --devimage)
     if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
       DEV_IMAGE=$2
+      shift 2
+    else
+      echo "Error: Argument for $1 is missing" >&2
+      usage
+    fi
+    ;;
+  --engine)
+    if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
+      ENGINE=$2
       shift 2
     else
       echo "Error: Argument for $1 is missing" >&2
@@ -102,5 +113,5 @@ if [[ $DOCKER_TARGET == 'runtime' ]]; then
   docker_args+=("--build-arg=IMAGE_VERSION=${DOCKER_TAG}")
 fi
 
-docker build . \
+$ENGINE build . \
   "${docker_args[@]}"


### PR DESCRIPTION
This PR will update the makefile and build scripts to allow developers to use podman as the build engine.
The default behaviour for the makefile will remain the same.

I ran the following to build images:

```
make build.develop ENGINE=podman
make build ENGINE=podman
```

I don't have a working docker env to test in.
cc @njhill 