### PR TITLE
Feat: Add PVC storage support

### DIFF
--- a/controllers/modelmesh/const.go
+++ b/controllers/modelmesh/const.go
@@ -29,6 +29,7 @@ const (
 	SocketVolume    = "domain-socket"
 
 	ConfigStorageMount = "storage-config"
+	PVCMount           = "pvc-mount"
 
 	//The name of the puller container
 	PullerContainerName = "puller"
@@ -45,11 +46,17 @@ const (
 	//The env variable puller uses to configure the config dir (secrets)
 	PullerEnvStorageConfigDir = "STORAGE_CONFIG_DIR"
 
+	//The env variable puller uses to configure the pvc dir (secrets)
+	PullerEnvPVCDir = "PVC_DIR"
+
 	//The puller default port number
 	PullerPortNumber = 8086
 
 	//The puller model mount path
 	PullerModelPath = "/models"
+
+	//The puller model PVC path
+	PullerPVCPath = "/pvc_mounts"
 
 	//The puller model config path
 	PullerConfigPath = "/storage-config"

--- a/controllers/modelmesh/const.go
+++ b/controllers/modelmesh/const.go
@@ -29,7 +29,6 @@ const (
 	SocketVolume    = "domain-socket"
 
 	ConfigStorageMount = "storage-config"
-	PVCMount           = "pvc-mount"
 
 	//The name of the puller container
 	PullerContainerName = "puller"
@@ -47,7 +46,7 @@ const (
 	PullerEnvStorageConfigDir = "STORAGE_CONFIG_DIR"
 
 	//The env variable puller uses to configure the pvc dir (secrets)
-	PullerEnvPVCDir = "PVC_DIR"
+	PullerEnvPVCDir = "PVC_MOUNTS_DIR"
 
 	//The puller default port number
 	PullerPortNumber = 8086
@@ -56,7 +55,7 @@ const (
 	PullerModelPath = "/models"
 
 	//The puller model PVC path
-	PullerPVCPath = "/pvc_mounts"
+	DefaultPVCMountsDir = "/pvc_mounts"
 
 	//The puller model config path
 	PullerConfigPath = "/storage-config"

--- a/controllers/modelmesh/modelmesh.go
+++ b/controllers/modelmesh/modelmesh.go
@@ -142,7 +142,7 @@ func (m *Deployment) Apply(ctx context.Context) error {
 
 	if useStorageHelper(m.SRSpec) {
 		manifest, err = manifest.Transform(
-			addPullerTransform(m.SRSpec, m.PullerImage, m.PullerImageCommand, m.PullerResources),
+			addPullerTransform(m.SRSpec, m.PullerImage, m.PullerImageCommand, m.PullerResources, m.PVCs),
 		)
 		if err != nil {
 			return fmt.Errorf("Error transforming: %w", err)

--- a/controllers/modelmesh/modelmesh.go
+++ b/controllers/modelmesh/modelmesh.go
@@ -53,7 +53,7 @@ type Deployment struct {
 	RESTProxyImage     string
 	RESTProxyResources *corev1.ResourceRequirements
 	RESTProxyPort      uint16
-	PVCs               map[string]struct{}
+	PVCs               []string
 	// internal fields used when templating
 	ModelMeshLimitCPU          string
 	ModelMeshRequestsCPU       string

--- a/controllers/modelmesh/modelmesh.go
+++ b/controllers/modelmesh/modelmesh.go
@@ -53,6 +53,7 @@ type Deployment struct {
 	RESTProxyImage     string
 	RESTProxyResources *corev1.ResourceRequirements
 	RESTProxyPort      uint16
+	PVCs               []string
 	// internal fields used when templating
 	ModelMeshLimitCPU          string
 	ModelMeshRequestsCPU       string

--- a/controllers/modelmesh/modelmesh.go
+++ b/controllers/modelmesh/modelmesh.go
@@ -53,7 +53,7 @@ type Deployment struct {
 	RESTProxyImage     string
 	RESTProxyResources *corev1.ResourceRequirements
 	RESTProxyPort      uint16
-	PVCs               []string
+	PVCs               map[string]struct{}
 	// internal fields used when templating
 	ModelMeshLimitCPU          string
 	ModelMeshRequestsCPU       string

--- a/controllers/modelmesh/puller.go
+++ b/controllers/modelmesh/puller.go
@@ -67,6 +67,9 @@ func addPullerSidecar(rts *kserveapi.ServingRuntimeSpec, deployment *appsv1.Depl
 			}, {
 				Name:  PullerEnvStorageConfigDir,
 				Value: PullerConfigPath,
+			}, {
+				Name:  PullerEnvPVCDir,
+				Value: PullerPVCPath,
 			},
 		},
 		Image:   pullerImage,
@@ -87,6 +90,11 @@ func addPullerSidecar(rts *kserveapi.ServingRuntimeSpec, deployment *appsv1.Depl
 			{
 				Name:      ConfigStorageMount,
 				MountPath: PullerConfigPath,
+				ReadOnly:  true,
+			},
+			{
+				Name:      PVCMount,
+				MountPath: PullerPVCPath,
 				ReadOnly:  true,
 			},
 		},

--- a/controllers/modelmesh/puller.go
+++ b/controllers/modelmesh/puller.go
@@ -14,6 +14,7 @@
 package modelmesh
 
 import (
+	"path/filepath"
 	"strconv"
 
 	kserveapi "github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
@@ -25,14 +26,14 @@ import (
 
 var StorageSecretName string
 
-func addPullerTransform(rts *kserveapi.ServingRuntimeSpec, pullerImage string, pullerImageCommand []string, pullerResources *corev1.ResourceRequirements) func(*unstructured.Unstructured) error {
+func addPullerTransform(rts *kserveapi.ServingRuntimeSpec, pullerImage string, pullerImageCommand []string, pullerResources *corev1.ResourceRequirements, pvcs []string) func(*unstructured.Unstructured) error {
 	return func(resource *unstructured.Unstructured) error {
 		var deployment = &appsv1.Deployment{}
 		if err := scheme.Scheme.Convert(resource, deployment, nil); err != nil {
 			return err
 		}
 
-		err := addPullerSidecar(rts, deployment, pullerImage, pullerImageCommand, pullerResources)
+		err := addPullerSidecar(rts, deployment, pullerImage, pullerImageCommand, pullerResources, pvcs)
 		if err != nil {
 			return err
 		}
@@ -41,7 +42,7 @@ func addPullerTransform(rts *kserveapi.ServingRuntimeSpec, pullerImage string, p
 	}
 }
 
-func addPullerSidecar(rts *kserveapi.ServingRuntimeSpec, deployment *appsv1.Deployment, pullerImage string, pullerImageCommand []string, pullerResources *corev1.ResourceRequirements) error {
+func addPullerSidecar(rts *kserveapi.ServingRuntimeSpec, deployment *appsv1.Deployment, pullerImage string, pullerImageCommand []string, pullerResources *corev1.ResourceRequirements, pvcs []string) error {
 	endpoint, err := ValidateEndpoint(*rts.GrpcMultiModelManagementEndpoint)
 	if err != nil {
 		return err
@@ -69,7 +70,7 @@ func addPullerSidecar(rts *kserveapi.ServingRuntimeSpec, deployment *appsv1.Depl
 				Value: PullerConfigPath,
 			}, {
 				Name:  PullerEnvPVCDir,
-				Value: PullerPVCPath,
+				Value: DefaultPVCMountsDir,
 			},
 		},
 		Image:   pullerImage,
@@ -92,11 +93,6 @@ func addPullerSidecar(rts *kserveapi.ServingRuntimeSpec, deployment *appsv1.Depl
 				MountPath: PullerConfigPath,
 				ReadOnly:  true,
 			},
-			{
-				Name:      PVCMount,
-				MountPath: PullerPVCPath,
-				ReadOnly:  true,
-			},
 		},
 	}
 
@@ -104,6 +100,13 @@ func addPullerSidecar(rts *kserveapi.ServingRuntimeSpec, deployment *appsv1.Depl
 		cspec.VolumeMounts = append(cspec.VolumeMounts, corev1.VolumeMount{
 			Name:      udsVolMountName,
 			MountPath: udsParentPath,
+		})
+	}
+	for _, pvcName := range pvcs {
+		cspec.VolumeMounts = append(cspec.VolumeMounts, corev1.VolumeMount{
+			Name:      pvcName,
+			MountPath: DefaultPVCMountsDir + string(filepath.Separator) + pvcName,
+			ReadOnly:  true,
 		})
 	}
 

--- a/controllers/modelmesh/puller_test.go
+++ b/controllers/modelmesh/puller_test.go
@@ -30,7 +30,7 @@ func TestPuller(t *testing.T) {
 	}
 	deployment := &appsv1.Deployment{}
 
-	err := addPullerSidecar(&rt.Spec, deployment, "", nil, &corev1.ResourceRequirements{})
+	err := addPullerSidecar(&rt.Spec, deployment, "", nil, &corev1.ResourceRequirements{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/controllers/modelmesh/runtime.go
+++ b/controllers/modelmesh/runtime.go
@@ -28,6 +28,7 @@ import (
 
 const (
 	ModelsDir     string  = "/models"
+	PVCRootDir    string  = "/pvc_mounts"
 	ModelDirScale float64 = 1.5
 )
 
@@ -81,6 +82,21 @@ func (m *Deployment) addVolumesToDeployment(deployment *appsv1.Deployment) error
 		volumes = append(volumes, storageVolume)
 	}
 
+	// need to add pvc volumes
+	for _, pvcName := range m.PVCs {
+		pvcVolume := corev1.Volume{
+			Name: pvcName,
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: pvcName,
+					ReadOnly:  true,
+				},
+			},
+		}
+
+		volumes = append(volumes, pvcVolume)
+	}
+
 	deployment.Spec.Template.Spec.Volumes = volumes
 
 	return nil
@@ -122,6 +138,16 @@ func (m *Deployment) addRuntimeToDeployment(deployment *appsv1.Deployment) error
 			Name:      ModelsDirVolume,
 			MountPath: ModelsDir,
 		},
+	}
+
+	for _, pvcName := range m.PVCs {
+		volumeMounts = append([]corev1.VolumeMount{
+			{
+				Name:      pvcName,
+				MountPath: PVCRootDir + "/" + pvcName,
+				ReadOnly:  true,
+			},
+		}, volumeMounts...)
 	}
 
 	// Now add the containers specified in serving runtime spec

--- a/controllers/modelmesh/runtime.go
+++ b/controllers/modelmesh/runtime.go
@@ -83,7 +83,7 @@ func (m *Deployment) addVolumesToDeployment(deployment *appsv1.Deployment) error
 	}
 
 	// need to add pvc volumes
-	for _, pvcName := range m.PVCs {
+	for pvcName := range m.PVCs {
 		pvcVolume := corev1.Volume{
 			Name: pvcName,
 			VolumeSource: corev1.VolumeSource{
@@ -140,7 +140,7 @@ func (m *Deployment) addRuntimeToDeployment(deployment *appsv1.Deployment) error
 		},
 	}
 
-	for _, pvcName := range m.PVCs {
+	for pvcName := range m.PVCs {
 		volumeMounts = append([]corev1.VolumeMount{
 			{
 				Name:      pvcName,

--- a/controllers/modelmesh/runtime.go
+++ b/controllers/modelmesh/runtime.go
@@ -83,7 +83,7 @@ func (m *Deployment) addVolumesToDeployment(deployment *appsv1.Deployment) error
 	}
 
 	// need to add pvc volumes
-	for pvcName := range m.PVCs {
+	for _, pvcName := range m.PVCs {
 		pvcVolume := corev1.Volume{
 			Name: pvcName,
 			VolumeSource: corev1.VolumeSource{
@@ -140,14 +140,12 @@ func (m *Deployment) addRuntimeToDeployment(deployment *appsv1.Deployment) error
 		},
 	}
 
-	for pvcName := range m.PVCs {
-		volumeMounts = append([]corev1.VolumeMount{
-			{
-				Name:      pvcName,
-				MountPath: PVCRootDir + "/" + pvcName,
-				ReadOnly:  true,
-			},
-		}, volumeMounts...)
+	for _, pvcName := range m.PVCs {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      pvcName,
+			MountPath: PVCRootDir + "/" + pvcName,
+			ReadOnly:  true,
+		})
 	}
 
 	// Now add the containers specified in serving runtime spec

--- a/controllers/predictor_controller.go
+++ b/controllers/predictor_controller.go
@@ -113,7 +113,7 @@ func (pr *PredictorReconciler) ReconcilePredictor(ctx context.Context, nname typ
 	mmc := pr.getMMClient(nname.Namespace)
 	var finalErr error
 
-	invalidPredictorMessage := pr.validatePredictor(predictor)
+	invalidPredictorMessage := validatePredictor(predictor)
 
 	if invalidPredictorMessage != "" {
 		log.Info("Invalid Predictor specification", "Spec", predictor.Spec)
@@ -224,7 +224,7 @@ func (pr *PredictorReconciler) ReconcilePredictor(ctx context.Context, nname typ
 
 // validatePredictor checks if there are incompatibilities in the spec
 // Returns a string describing the reason a Predictor is invalid, empty if valid.
-func (pr *PredictorReconciler) validatePredictor(predictor *api.Predictor) string {
+func validatePredictor(predictor *api.Predictor) string {
 	// if it exists, inspect and validate the storage specification
 	if predictor.Spec.Storage == nil {
 		return ""

--- a/controllers/predictor_controller.go
+++ b/controllers/predictor_controller.go
@@ -339,8 +339,6 @@ func (pr *PredictorReconciler) setVModel(ctx context.Context, mmc mmeshapi.Model
 
 	setVmodelCtx, cancel := context.WithTimeout(ctx, GrpcRequestTimeout)
 	defer cancel()
-	pr.Log.Info("===Chin===", "predictor.Spec.Storage.StorageKey", predictor.Spec.Storage.StorageKey)
-	pr.Log.Info("===Chin===", "predictor.Spec.Storage", predictor.Spec.Storage.StorageSpec)
 
 	path, schemaPath, storageKey, storageParams := extractModelFields(predictor)
 

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -53,6 +53,7 @@ The following parameters are currently supported. _Note_ the keys are expressed 
 | `runtimePodLabels`                         | `metadata.labels` to be added to all `ServingRuntime` pods                                            | (\*\*\*\*\*) See default labels below      |
 | `runtimePodAnnotations`                    | `metadata.annotations` to be added to all `ServingRuntime` pods                                       | (\*\*\*\*\*) See default annotations below |
 | `imagePullSecrets`                         | The image pull secrets to use for runtime Pods                                                        |                                            |
+| `allowAnyPVC`                              | Allows any PVC in predictor to configure PVC for runtime pods when it's not in storage secret         | `false`                                    |
 
 (\*) Currently requires a controller restart to take effect
 

--- a/fvt/predictor/predictor_test.go
+++ b/fvt/predictor/predictor_test.go
@@ -1009,20 +1009,6 @@ var _ = Describe("Invalid Predictors", func() {
 				// TODO can we check for a more detailed error message?
 			})
 
-			It("predictor should fail to load with unsupported storage type", func() {
-				// modify the object with a PVC storage type, which isn't yet supported
-				err := unstructured.SetNestedField(predictorObject.Object, map[string]interface{}{
-					"claimName": "not-yet-supported",
-				}, "spec", "storage", "persistentVolumeClaim")
-				Expect(err).ToNot(HaveOccurred())
-
-				obj := CreatePredictorAndWaitAndExpectInvalidSpec(predictorObject)
-
-				By("Asserting on the predictor state")
-				ExpectPredictorFailureInfo(obj, "InvalidPredictorSpec", false, false,
-					"spec.storage.PersistentVolumeClaim is not supported")
-			})
-
 			It("predictor should fail to load with unrecognized model type", func() {
 				// modify the object with an unrecognized model type
 				SetString(predictorObject, "invalidModelType", "spec", "modelType", "name")

--- a/main.go
+++ b/main.go
@@ -78,6 +78,7 @@ const (
 	LeaderForLifeLockName             = "modelmesh-controller-leader-for-life-lock"
 	EnableInferenceServiceEnvVar      = "ENABLE_ISVC_WATCH"
 	EnableClusterServingRuntimeEnvVar = "ENABLE_CSR_WATCH"
+	EnableSecretEnvVar                = "ENABLE_SECRET_WATCH"
 	NamespaceScopeEnvVar              = "NAMESPACE_SCOPE"
 	TrueString                        = "true"
 )
@@ -357,6 +358,26 @@ func main() {
 	}
 	enableCSRWatch := checkCSRVar(EnableClusterServingRuntimeEnvVar, "ClusterServingRuntime", &v1alpha1.ClusterServingRuntime{})
 
+	checkSecretVar := func(envVar string, resourceName string, resourceObject client.Object) bool {
+
+		envVarVal, _ := os.LookupEnv(envVar)
+		if envVarVal != "false" {
+			err = cl.Get(context.Background(), client.ObjectKey{Name: "foo", Namespace: ControllerNamespace}, resourceObject)
+			if err == nil || errors.IsNotFound(err) {
+				setupLog.Info(fmt.Sprintf("Reconciliation of %s is enabled", resourceName))
+				return true
+			} else if envVarVal == TrueString {
+				// If env var is explicitly true, require that specified CRD is present
+				setupLog.Error(err, fmt.Sprintf("Unable to access %s resource", resourceName))
+				os.Exit(1)
+			} else {
+				setupLog.Error(err, fmt.Sprintf("%s CRD not accessible, will not reconcile", resourceName))
+			}
+		}
+		return false
+	}
+	enableSecretWatch := checkSecretVar(EnableSecretEnvVar, "Secret", &corev1.Secret{})
+
 	var predictorControllerEvents, runtimeControllerEvents chan event.GenericEvent
 	if len(sources) != 0 {
 		predictorControllerEvents = make(chan event.GenericEvent, 256)
@@ -420,6 +441,7 @@ func main() {
 		ControllerName:      controllerDeploymentName,
 		ClusterScope:        clusterScopeMode,
 		EnableCSRWatch:      enableCSRWatch,
+		EnableSecretWatch:   enableSecretWatch,
 		RegistryMap:         registryMap,
 	}).SetupWithManager(mgr, enableIsvcWatch, runtimeControllerEvents); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ServingRuntime")

--- a/main.go
+++ b/main.go
@@ -79,7 +79,6 @@ const (
 	EnableInferenceServiceEnvVar      = "ENABLE_ISVC_WATCH"
 	EnableClusterServingRuntimeEnvVar = "ENABLE_CSR_WATCH"
 	EnableSecretEnvVar                = "ENABLE_SECRET_WATCH"
-	DeployPVCForPredictorEnvVar       = "DEPLOY_PVC_FOR_PREDICTOR"
 	NamespaceScopeEnvVar              = "NAMESPACE_SCOPE"
 	TrueString                        = "true"
 	FalseString                       = "false"
@@ -364,7 +363,7 @@ func main() {
 		// default is true
 		envVarVal, _ := os.LookupEnv(envVar)
 		if envVarVal != FalseString {
-			err = cl.Get(context.Background(), client.ObjectKey{Name: "foo", Namespace: ControllerNamespace}, resourceObject)
+			err = cl.Get(context.Background(), client.ObjectKey{Name: "storage-config", Namespace: ControllerNamespace}, resourceObject)
 			if err == nil || errors.IsNotFound(err) {
 				setupLog.Info(fmt.Sprintf("Reconciliation of %s is enabled", resourceName))
 				return true
@@ -379,13 +378,6 @@ func main() {
 		return false
 	}
 	enableSecretWatch := checkSecretVar(EnableSecretEnvVar, "Secret", &corev1.Secret{})
-
-	checkDeployPVCForPredictorVar := func(envVar string) bool {
-		// default is false
-		envVarVal, _ := os.LookupEnv(envVar)
-		return envVarVal == TrueString
-	}
-	deployPVCForPredictor := checkDeployPVCForPredictorVar(DeployPVCForPredictorEnvVar)
 
 	var predictorControllerEvents, runtimeControllerEvents chan event.GenericEvent
 	if len(sources) != 0 {
@@ -451,7 +443,7 @@ func main() {
 		ClusterScope:          clusterScopeMode,
 		EnableCSRWatch:        enableCSRWatch,
 		EnableSecretWatch:     enableSecretWatch,
-		DeployPVCForPredictor: deployPVCForPredictor,
+		DeployPVCForPredictor: conf.EnableDeployPVCForPredictor,
 		RegistryMap:           registryMap,
 	}).SetupWithManager(mgr, enableIsvcWatch, runtimeControllerEvents); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ServingRuntime")

--- a/main.go
+++ b/main.go
@@ -433,18 +433,17 @@ func main() {
 	}
 
 	if err = (&controllers.ServingRuntimeReconciler{
-		Client:                mgr.GetClient(),
-		Log:                   ctrl.Log.WithName("controllers").WithName("ServingRuntime"),
-		Scheme:                mgr.GetScheme(),
-		ConfigProvider:        cp,
-		ConfigMapName:         types.NamespacedName{Namespace: ControllerNamespace, Name: UserConfigMapName},
-		ControllerNamespace:   ControllerNamespace,
-		ControllerName:        controllerDeploymentName,
-		ClusterScope:          clusterScopeMode,
-		EnableCSRWatch:        enableCSRWatch,
-		EnableSecretWatch:     enableSecretWatch,
-		DeployPVCForPredictor: conf.EnableDeployPVCForPredictor,
-		RegistryMap:           registryMap,
+		Client:              mgr.GetClient(),
+		Log:                 ctrl.Log.WithName("controllers").WithName("ServingRuntime"),
+		Scheme:              mgr.GetScheme(),
+		ConfigProvider:      cp,
+		ConfigMapName:       types.NamespacedName{Namespace: ControllerNamespace, Name: UserConfigMapName},
+		ControllerNamespace: ControllerNamespace,
+		ControllerName:      controllerDeploymentName,
+		ClusterScope:        clusterScopeMode,
+		EnableCSRWatch:      enableCSRWatch,
+		EnableSecretWatch:   enableSecretWatch,
+		RegistryMap:         registryMap,
 	}).SetupWithManager(mgr, enableIsvcWatch, runtimeControllerEvents); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ServingRuntime")
 		os.Exit(1)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -55,9 +55,9 @@ var (
 // Config holds process global configuration information
 type Config struct {
 	// System config
-	EtcdSecretName              string // DEPRECATED - should be removed in the future
-	ModelMeshEndpoint           string // For dev use only
-	EnableDeployPVCForPredictor bool
+	EtcdSecretName    string // DEPRECATED - should be removed in the future
+	ModelMeshEndpoint string // For dev use only
+	AllowAnyPVC       bool
 
 	// Service config
 	InferenceServiceName    string

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -55,8 +55,9 @@ var (
 // Config holds process global configuration information
 type Config struct {
 	// System config
-	EtcdSecretName    string // DEPRECATED - should be removed in the future
-	ModelMeshEndpoint string // For dev use only
+	EtcdSecretName              string // DEPRECATED - should be removed in the future
+	ModelMeshEndpoint           string // For dev use only
+	EnableDeployPVCForPredictor bool
 
 	// Service config
 	InferenceServiceName    string

--- a/pkg/predictor_source/inferenceservice_registry.go
+++ b/pkg/predictor_source/inferenceservice_registry.go
@@ -335,9 +335,26 @@ func (isvcr InferenceServiceRegistry) Find(ctx context.Context, namespace string
 	}
 
 	for i := range list.Items {
-		p, _ := BuildBasePredictorFromInferenceService(&list.Items[i])
-		if p != nil && predicate(p) {
+		inferenceService := &list.Items[i]
+		nname := types.NamespacedName{Name: inferenceService.Name, Namespace: inferenceService.Namespace}
+		p, err := BuildBasePredictorFromInferenceService(inferenceService)
+		if err != nil {
 			return true, nil
+		}
+		if p != nil {
+			secretKey, parameters, modelPath, schemaPath, err := processInferenceServiceStorage(inferenceService, nname)
+			if err != nil {
+				return true, nil
+			}
+			p.Spec.Storage = &v1alpha1.Storage{}
+			p.Spec.Storage.Path = &modelPath
+			p.Spec.Storage.SchemaPath = schemaPath
+			p.Spec.Storage.Parameters = &parameters
+			p.Spec.Storage.StorageKey = secretKey
+
+			if predicate(p) {
+				return true, nil
+			}
 		}
 	}
 	return false, nil

--- a/pkg/predictor_source/inferenceservice_registry.go
+++ b/pkg/predictor_source/inferenceservice_registry.go
@@ -28,6 +28,7 @@ import (
 	"github.com/kserve/modelmesh-serving/apis/serving/v1alpha1"
 	"knative.dev/pkg/apis"
 
+	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -39,6 +40,7 @@ const (
 	runtimeAnnotation    = "serving.kserve.io/servingRuntime"
 
 	azureBlobHostSuffix = "blob.core.windows.net"
+	pvcStorageType      = "pvc"
 )
 
 var _ PredictorRegistry = (*InferenceServiceRegistry)(nil)
@@ -162,6 +164,10 @@ func processInferenceServiceStorage(inferenceService *v1beta1.InferenceService, 
 		}
 
 		switch u.Scheme {
+		case pvcStorageType:
+			modelPath = strings.TrimPrefix(u.Path, "/")
+			uriParameters["type"] = pvcStorageType
+			uriParameters["name"] = u.Host
 		case "s3":
 			modelPath = strings.TrimPrefix(u.Path, "/")
 			uriParameters["type"] = "s3"
@@ -318,7 +324,11 @@ func (isvcr InferenceServiceRegistry) Get(ctx context.Context, nname types.Names
 	p.Spec.Storage.SchemaPath = schemaPath
 	p.Spec.Storage.Parameters = &parameters
 	p.Spec.Storage.StorageKey = secretKey
-
+	if parameters["type"] == pvcStorageType {
+		p.Spec.Storage.PersistentVolumeClaim = &corev1.PersistentVolumeClaimVolumeSource{}
+		p.Spec.Storage.PersistentVolumeClaim.ClaimName = parameters["name"]
+		p.Spec.Storage.PersistentVolumeClaim.ReadOnly = true
+	}
 	return p, nil
 
 }

--- a/pkg/predictor_source/inferenceservice_registry.go
+++ b/pkg/predictor_source/inferenceservice_registry.go
@@ -28,7 +28,6 @@ import (
 	"github.com/kserve/modelmesh-serving/apis/serving/v1alpha1"
 	"knative.dev/pkg/apis"
 
-	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -40,7 +39,6 @@ const (
 	runtimeAnnotation    = "serving.kserve.io/servingRuntime"
 
 	azureBlobHostSuffix = "blob.core.windows.net"
-	pvcStorageType      = "pvc"
 )
 
 var _ PredictorRegistry = (*InferenceServiceRegistry)(nil)
@@ -164,9 +162,9 @@ func processInferenceServiceStorage(inferenceService *v1beta1.InferenceService, 
 		}
 
 		switch u.Scheme {
-		case pvcStorageType:
+		case "pvc":
 			modelPath = strings.TrimPrefix(u.Path, "/")
-			uriParameters["type"] = pvcStorageType
+			uriParameters["type"] = "pvc"
 			uriParameters["name"] = u.Host
 		case "s3":
 			modelPath = strings.TrimPrefix(u.Path, "/")
@@ -324,11 +322,6 @@ func (isvcr InferenceServiceRegistry) Get(ctx context.Context, nname types.Names
 	p.Spec.Storage.SchemaPath = schemaPath
 	p.Spec.Storage.Parameters = &parameters
 	p.Spec.Storage.StorageKey = secretKey
-	if parameters["type"] == pvcStorageType {
-		p.Spec.Storage.PersistentVolumeClaim = &corev1.PersistentVolumeClaimVolumeSource{}
-		p.Spec.Storage.PersistentVolumeClaim.ClaimName = parameters["name"]
-		p.Spec.Storage.PersistentVolumeClaim.ReadOnly = true
-	}
 	return p, nil
 
 }


### PR DESCRIPTION
#### Motivation
Support PVC as a storage option, to address issue https://github.com/kserve/modelmesh-serving/issues/230

#### Modifications

- Add PVCs to deployment
- Add secret watch to ServingRuntime controller to update deployment
- Add logic to ServingRuntime controller to create PVCs for predictors if the global setting is true
- Create volumes and PVCs based on deployment for ServingRuntimes
- Update Predictor controller to validate for PVCs

#### Result

- PVCs are read from the storage secret and created for all ServingRuntimes
- PVCs are read from the predictor spec and created for all ServingRuntimes if the global setting is true

#### Related Issues

- https://github.com/kserve/modelmesh-serving/issues/230
- https://github.com/kserve/modelmesh-runtime-adapter/pull/36

---

Resolves #230