### PR TITLE
docs: Update Custom Runtime Docs

### DIFF
--- a/docs/runtimes/README.md
+++ b/docs/runtimes/README.md
@@ -1,10 +1,7 @@
 # Serving Runtimes
 
-ModelMesh Serving includes some built-in Serving Runtimes for common ML frameworks, but also supports custom Runtimes. Custom Runtimes are created by building a new container image with support for the desired framework and then creating a `ServingRuntime` custom resource using that image.
+ModelMesh Serving includes some built-in `ServingRuntime`s for common ML frameworks, but also supports custom runtimes. Custom runtimes are created by building a new container image with support for the desired framework and then creating a `ServingRuntime` custom resource using that image.
 
-If the desired Custom Runtime uses an ML framework with Python bindings, there is a simplified process to building and integrating a Custom Runtime. This approach is detailed in the
-[Python Based Custom Runtime on MLServer](./mlserver_custom.md)
-page.
+If the desired custom runtime uses an ML framework with Python bindings, there is a simplified process to build and integrate a custom cuntime. This approach is detailed in the [Python-based Custom Runtime on MLServer](./mlserver_custom.md) page.
 
-In general, the implementation of a complete runtime requires integrating with the Model Mesh API
-[as detailed on the Custom Runtimes page](./custom_runtimes.md).
+In general, the implementation of a complete runtime requires integration with the Model Mesh API [as detailed on the Custom Runtimes page](./custom_runtimes.md).


### PR DESCRIPTION
#### Motivation
While creating a Python-based custom runtime, I found that some of the documentation and templates could be a bit more helpful with naming conventions, hints, and formatting to match the [MLServer built-in runtime](https://github.com/kserve/modelmesh-serving/blob/main/config/runtimes/mlserver-0.x.yaml) for ease of comparison.

#### Modifications
Copy-edited docs while adding help and clarification to templates.

#### Result
Friendlier documentation for building and deploying custom runtimes.