### PR TITLE
Fix FVT runtime count issue

### DIFF
--- a/config/runtimes/torchserve-0.x.yaml
+++ b/config/runtimes/torchserve-0.x.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 apiVersion: serving.kserve.io/v1alpha1
-kind: ServingRuntime
+kind: ClusterServingRuntime
 metadata:
   name: torchserve-0.x
   labels:


### PR DESCRIPTION
Fix FVT runtime count issue by making torchserve as cluster serving runtime as default, similar to other out-of-the-box runtimes

Signed-off-by: Chin Huang <chhuang@us.ibm.com>

#### Motivation
Make FVT working in the default cluster scoped mode

#### Modifications
Change torchserve-0.x to be a ClusterRuntime
Add a line to e2e FVT to disable torchserve-0.x, similar to github actions

#### Result
FVT working in cluster scoped mode
e2e working