### PR TITLE
fix: config-defaults mount path

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -81,7 +81,7 @@ spec:
               cpu: "1"
               memory: 512Mi
           volumeMounts:
-            - mountPath: /etc/model-serving/config-defaults.yaml
+            - mountPath: /etc/model-serving/config/default
               name: config-defaults
               readOnly: true
           securityContext:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -43,7 +43,7 @@ const (
 	DefaultEtcdSecretName = "model-serving-etcd"
 
 	ConfigType        = "yaml"
-	MountLocation     = "/etc/model-serving/config-defaults.yaml"
+	MountLocation     = "/etc/model-serving/config/default"
 	ViperKeyDelimiter = "::"
 )
 


### PR DESCRIPTION
#### Motivation

The file containing the default configuration for the ModelMesh Controller is called `config-defaults.yaml`, which resides in a directory also called `config-defaults.yaml` as pointed out by @adrwong-lora in issue #205
```
/etc/model-serving/config-defaults.yaml/config-defaults.yaml
```

#### Modifications

Change `mountPath` from `/etc/model-serving/config-defaults.yaml` to `/etc/model-serving/config/default`

#### Result

The file containing the default configuration file after this fix:

```
/etc/model-serving/config/default/config-defaults.yaml
```

Which more closely reflects the path of the [`config-defaults.yaml`](https://github.com/kserve/modelmesh-serving/blob/main/config/default/config-defaults.yaml) file in the `modelmesh-serving` repository:
```
config/default/config-defaults.yaml
```

Resolves #205 

/cc @njhill 
/fyi @adrwong-lora