### PR TITLE
doc: include namespace-scope info

### DIFF
--- a/docs/install/install-script.md
+++ b/docs/install/install-script.md
@@ -68,7 +68,7 @@ usage: ./scripts/install.sh [flags]
 
 Flags:
   -n, --namespace                (required) Kubernetes namespace to deploy ModelMesh Serving to.
-  -p, --install-config-path      Path to local model serve installation configs. Can be ModelMesh Serving tarfile or directory.
+  -p, --install-config-path      Path to installation configs. Can be a local ModelMesh Serving config tarfile/directory or a URL to a config tarfile.
   -d, --delete                   Delete any existing instances of ModelMesh Serving in Kube namespace before running install, including CRDs, RBACs, controller, older CRD with serving.kserve.io api group name, etc.
   -u, --user-namespaces          Kubernetes namespaces to enable for ModelMesh Serving
   --quickstart                   Install and configure required supporting datastores in the same namespace (etcd and MinIO) - for experimentation/development
@@ -80,7 +80,7 @@ Installs ModelMesh Serving CRDs, controller, and built-in runtimes into specifie
 Kubernetes namespaces.
 
 Expects cluster-admin authority and Kube cluster access to be configured prior to running.
-Also requires Etcd secret 'model-serving-etcd' to be created in namespace already.
+Also requires etcd secret 'model-serving-etcd' to be created in namespace already.
 ```
 
 You can optionally provide a local `--install-config-path` that points to a local ModelMesh Serving tar file or directory containing ModelMesh Serving configs to deploy. If not specified, the `config` directory from the root of the project will be used.
@@ -88,6 +88,8 @@ You can optionally provide a local `--install-config-path` that points to a loca
 You can also optionally use `--delete` to delete any existing instances of ModelMesh Serving in the designated Kube namespace before running the install.
 
 The installation will create a secret named `storage-config` if it does not already exist. If the `--quickstart` option was chosen, this will be populated with the connection details for the example models bucket in IBM Cloud Object Storage and the local MinIO; otherwise, it will be empty and ready for you to add your own entries.
+
+The `--namespace-scope-mode` will deploy `ServingRuntime`s confined to the same namespace, instead of the default cluster-scoped runtimes `ClusterServingRuntime`s. These serving runtimes are accessible to any user/namespace in the cluster.
 
 ## Setup additional namespaces
 


### PR DESCRIPTION
#### Motivation
There doesn't seem to be much information about what the `--namespace-scope-mode` flag does, or the difference between cluster-scoped and namespace-scoped serving runtimes.

#### Modifications
- As a start, a blurb is included for the `--namespace-scope-mode` flag in the `install-script` doc.
- Corrects the `--help` output as well.

#### Result
Helpful information about the `--namespace-scope-mode` which is included in the recommended way to use the quick-start install of ModelMesh.