### PR TITLE
chore: Run GitHub actions on `release-*` branches

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -2,7 +2,9 @@ name: Build and Push
 
 on:
   push:
-    branches: [main]
+    branches:
+      - 'main'
+      - 'release-*'
     paths-ignore:
       - 'docs/**'
       - '**.md'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,9 @@ name: Lint
 
 on:
   pull_request:
-    branches: [main]
+    branches:
+      - 'main'
+      - 'release-*'
     paths-ignore:
       - '.github/**'
       - '.tekton/**'

--- a/.github/workflows/run-fvt.yml
+++ b/.github/workflows/run-fvt.yml
@@ -2,7 +2,9 @@ name: FVTs
 
 on:
   pull_request:
-    branches: [main]
+    branches:
+      - 'main'
+      - 'release-*'
     paths:
       - '**'
       - '!.github/**'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -2,7 +2,9 @@ name: Unit Test
 
 on:
   pull_request:
-    branches: [main]
+    branches:
+      - 'main'
+      - 'release-*'
     paths-ignore:
       - 'docs/**'
       - '**.md'


### PR DESCRIPTION
#### Motivation

When we create a new release we need the GitHub actions to run for 
- Lint
- Unit test
- FVT
- Image build and push

#### Modifications

Update the Github workflow definitions to include any `release-..` branches.

#### Result

The GitHub action run on PR and pushed to the release branch.

As can be seen in this PR targeting the `release-0.10` branch:
https://github.com/kserve/modelmesh-serving/pull/298

---

**Note**: same (intended) changes as in PR #299 -- but without the merge commits

/cc @njhill @rafvasq 
/assign @njhill 