### PR TITLE
fix: etcd pod fails to start on OpenShift

### DIFF
--- a/config/dependencies/quickstart.yaml
+++ b/config/dependencies/quickstart.yaml
@@ -43,7 +43,7 @@ spec:
       containers:
         - command:
             - etcd
-            - --data-dir  # use data directory under /tmp for read/write access by non-root user on OpenShift
+            - --data-dir # use data directory under /tmp for read/write access by non-root user on OpenShift
             - /tmp/etcd.data
             - --listen-client-urls
             - http://0.0.0.0:2379

--- a/config/dependencies/quickstart.yaml
+++ b/config/dependencies/quickstart.yaml
@@ -43,6 +43,8 @@ spec:
       containers:
         - command:
             - etcd
+            - --data-dir
+            - /tmp/etcd.data
             - --listen-client-urls
             - http://0.0.0.0:2379
             - --advertise-client-urls

--- a/config/dependencies/quickstart.yaml
+++ b/config/dependencies/quickstart.yaml
@@ -43,7 +43,7 @@ spec:
       containers:
         - command:
             - etcd
-            - --data-dir
+            - --data-dir  # use data directory under /tmp for read/write access by non-root user on OpenShift
             - /tmp/etcd.data
             - --listen-client-urls
             - http://0.0.0.0:2379


### PR DESCRIPTION
#### Motivation

Addressing file access permission issues on OpenShift reported in issues #210 and #215 for the `etcd` deployment.

#### Modifications

Adding `data-dir` parameter to the container `args`:

```
- --data-dir
- /tmp/etcd.data
```


#### Result

The `etcd` pod comes up fine and spot-testing a few basic use cases went fine. I tested on IBM Cloud Kubernetes 1.24 and OCP 4.10

---

Resolves #210
Resolves #215