### PR TITLE
fix: update links to env var lines

### DIFF
--- a/controllers/modelmesh/modelmesh.go
+++ b/controllers/modelmesh/modelmesh.go
@@ -258,24 +258,24 @@ func (m *Deployment) addMMEnvVars(deployment *appsv1.Deployment) error {
 	}
 
 	if m.EnableAccessLogging {
-		//See https://github.com/kserve/modelmesh/blob/main/src/main/java/com/ibm/watson/modelmesh/ModelMeshEnvVars.java#L52
+		// See https://github.com/kserve/modelmesh/blob/v0.10.0/src/main/java/com/ibm/watson/modelmesh/ModelMeshEnvVars.java#L50
 		if err := setEnvironmentVar(ModelMeshContainerName, "MM_LOG_EACH_INVOKE", "true", deployment); err != nil {
 			return err
 		}
 	}
 
 	if m.GrpcMaxMessageSize > 0 {
-		//See https://github.com/kserve/modelmesh/blob/main/src/main/java/com/ibm/watson/modelmesh/ModelMeshEnvVars.java#L38
+		// See https://github.com/kserve/modelmesh/blob/v0.10.0/src/main/java/com/ibm/watson/modelmesh/ModelMeshEnvVars.java#L34
 		if err := setEnvironmentVar(ModelMeshContainerName, "MM_SVC_GRPC_MAX_MSG_SIZE", strconv.Itoa(m.GrpcMaxMessageSize), deployment); err != nil {
 			return err
 		}
 	}
 
-	// See https://github.com/kserve/modelmesh/blob/main/src/main/java/com/ibm/watson/modelmesh/ModelMeshEnvVars.java#L31
+	// See https://github.com/kserve/modelmesh/blob/v0.10.0/src/main/java/com/ibm/watson/modelmesh/ModelMeshEnvVars.java#L27
 	if err := setEnvironmentVar(ModelMeshContainerName, "MM_KVSTORE_PREFIX", ModelMeshEtcdPrefix, deployment); err != nil {
 		return err
 	}
-	// See https://github.com/kserve/modelmesh/blob/main/src/main/java/com/ibm/watson/modelmesh/ModelMeshEnvVars.java#L65
+	// See https://github.com/kserve/modelmesh/blob/v0.10.0/src/main/java/com/ibm/watson/modelmesh/ModelMeshEnvVars.java#L63
 	if err := setEnvironmentVar(ModelMeshContainerName, "MM_DEFAULT_VMODEL_OWNER", m.DefaultVModelOwner, deployment); err != nil {
 		return err
 	}


### PR DESCRIPTION
#### Motivation
Links pointing to ModelMesh environment variables are no longer accurate.

#### Modifications
Update the line numbers to point to the correct places in [ModelMeshEnvVars.java](https://github.com/kserve/modelmesh/blob/main/src/main/java/com/ibm/watson/modelmesh/ModelMeshEnvVars.java)
