### PR TITLE
doc: Add a note to Quickstart about known M1 issue 

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -20,6 +20,8 @@ cd modelmesh-serving
 
 ### Run install script
 
+**Note**: This will not work on M1 Mac laptops until [issue 162](https://github.com/kserve/modelmesh-serving/issues/162) is closed. 
+
 ```shell
 kubectl create namespace modelmesh-serving
 ./scripts/install.sh --namespace-scope-mode --namespace modelmesh-serving --quickstart


### PR DESCRIPTION
#### Motivation
To prevent a new user using an M1 chip laptop from wasting any time using the installation commands in the quickstart documentation, until [issue 162](https://github.com/kserve/modelmesh-serving/issues/162) is resolved and closed.

#### Modifications
Modified the quickstart documentation with this information.

#### Result
