### PR TITLE
release: Prepare v0.11.0-alpha release

### DIFF
--- a/.github/workflows/run-fvt.yml
+++ b/.github/workflows/run-fvt.yml
@@ -73,9 +73,9 @@ jobs:
           docker pull seldonio/mlserver:0.5.2
           docker pull openvino/model_server:2022.2
           # docker pull pytorch/torchserve:0.6.0-cpu
-          docker pull kserve/modelmesh-runtime-adapter
-          docker pull kserve/rest-proxy
-          docker pull kserve/modelmesh
+          docker pull kserve/modelmesh:v0.11.0-alpha
+          docker pull kserve/modelmesh-runtime-adapter:v0.11.0-alpha
+          docker pull kserve/rest-proxy:v0.10.0
       - name: Check installation
         run: |
           docker images

--- a/config/default/config-defaults.yaml
+++ b/config/default/config-defaults.yaml
@@ -16,7 +16,7 @@ podsPerRuntime: 2
 headlessService: true
 modelMeshImage:
   name: kserve/modelmesh
-  tag: latest
+  tag: v0.11.0-alpha
 modelMeshResources:
   requests:
     cpu: "300m"
@@ -29,7 +29,7 @@ restProxy:
   port: 8008
   image:
     name: kserve/rest-proxy
-    tag: latest
+    tag: v0.10.0
   resources:
     requests:
       cpu: "50m"
@@ -39,7 +39,7 @@ restProxy:
       memory: "512Mi"
 storageHelperImage:
   name: kserve/modelmesh-runtime-adapter
-  tag: latest
+  tag: v0.11.0-alpha
   command: ["/opt/app/puller"]
 storageHelperResources:
   requests:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -18,4 +18,4 @@ images:
   - name: modelmesh-controller
     newName: kserve/modelmesh-controller
     ## NOTE THIS SHOULD BE REPLACED WITH LATEST CONTROLLER IMAGE TAG
-    newTag: latest
+    newTag: v0.11.0-alpha

--- a/docs/component-versions.md
+++ b/docs/component-versions.md
@@ -1,8 +1,8 @@
 # Component versions
 
-The following table shows the component versions for the latest modelmesh-serving release (v0.10.0).
+The following table shows the component versions for the modelmesh-serving preview release (`v0.11.0-alpha`).
 | Component | Description | Upstream Revision |
 | - | - | - |
-| ModelMesh | Serves as a general-purpose model serving management/routing layer | [v0.10.0](https://github.com/kserve/modelmesh/tree/v0.10.0) |
-| ModelMesh Runtime Adapter | Contains the unified puller/runtime-adapter image | [v0.10.0](https://github.com/kserve/modelmesh-runtime-adapter/tree/v0.10.0) |
+| ModelMesh | Serves as a general-purpose model serving management/routing layer | [v0.11.0-alpha](https://github.com/kserve/modelmesh/tree/v0.11.0-alpha) |
+| ModelMesh Runtime Adapter | Contains the unified puller/runtime-adapter image | [v0.11.0-alpha](https://github.com/kserve/modelmesh-runtime-adapter/tree/v0.11.0-alpha) |
 | REST Proxy | Supports inference requests using KServe V2 REST Predict Protocol | [v0.10.0](https://github.com/kserve/rest-proxy/tree/v0.10.0) |

--- a/docs/install/install-script.md
+++ b/docs/install/install-script.md
@@ -40,10 +40,10 @@ A secret named `model-serving-etcd` will be created and passed to the controller
 
 ## Installation
 
-Install the latest release of [modelmesh-serving](https://github.com/kserve/modelmesh-serving/releases/latest) by first cloning the corresponding release branch:
+Install the latest release of [modelmesh-serving](https://github.com/kserve/modelmesh-serving/releases/v0.11.0-alpha) by first cloning the corresponding release branch:
 
 ```shell
-RELEASE=release-0.10
+RELEASE="release-0.11-alpha"
 git clone -b $RELEASE --depth 1 --single-branch https://github.com/kserve/modelmesh-serving.git
 cd modelmesh-serving
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,15 +5,15 @@ To quickly get started using ModelMesh Serving, here is a brief guide.
 ## Prerequisites
 
 - A Kubernetes cluster v 1.16+ with cluster administrative privileges
-- [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) and [kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/) (v3.2.0+)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) and [kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/) (v4.0.0+)
 - At least 4 vCPU and 8 GB memory. For more details, please see [here](install/README.md#deployed-components).
 
 ## 1. Install ModelMesh Serving
 
-### Get the latest release
+### Get the `v0.11.0-alpha` release
 
 ```shell
-RELEASE=release-0.10
+RELEASE="release-0.11-alpha"
 git clone -b $RELEASE --depth 1 --single-branch https://github.com/kserve/modelmesh-serving.git
 cd modelmesh-serving
 ```

--- a/scripts/setup_user_namespaces.sh
+++ b/scripts/setup_user_namespaces.sh
@@ -13,28 +13,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.#
 
-USAGE="$(
+USAGE=$(
   cat <<EOF
+
 Run this script to enable user namespaces for ModelMesh Serving, and optionally add the storage secret
 for example models and built-in serving runtimes to the target namespaces.
 
 usage: $0 [flags]
   Flags:
-    -u, --user-namespaces         (required) Kubernetes user namespaces to enable for ModelMesh
-    -c, --controller-namespace    Kubernetes ModelMesh controller namespace, default is modelmesh-serving
-    --create-storage-secret       Create storage secret for example models
-    --deploy-serving-runtimes     Deploy built-in serving runtimes
-    --dev-mode                    Run in development mode meaning the configs are local, not release based
-    -h, --help                    Display this help
+    -u, --user-namespaces       (required) Kubernetes user namespaces to enable for ModelMesh
+    -c, --controller-namespace  Kubernetes ModelMesh controller namespace, default is modelmesh-serving
+    --create-storage-secret     Create storage secret for example models
+    --deploy-serving-runtimes   Deploy built-in serving runtimes
+    --dev-mode                  Run in development mode meaning the configs are local, not release based
+    -h, --help                  Display this help
 EOF
-)"
+)
 
 ctrl_ns="modelmesh-serving"
 user_ns_array=()
-modelmesh_release="v0.10.0"       # The latest release is the default
+modelmesh_release="v0.11.0-alpha"   # The v0.11.0-alpha release is the default
 create_storage_secret=false
 deploy_serving_runtimes=false
-dev_mode=false                    # Set to true to use locally cloned files instead of from a release
+dev_mode=false                      # Set to true to use locally cloned files instead of from a release
 
 while (($# > 0)); do
   case "$1" in


### PR DESCRIPTION
#### Motivation

Tech preview release including:

- #230
- #337
- #284


#### Modifications

1. Create new tech preview release tag `v0.11.0-alpha` in these repositories:

   - [x] [`modelmesh`](https://github.com/kserve/modelmesh/releases)
   - [ ] ~~[`modelmesh-minio-examples`](https://github.com/kserve/modelmesh-runtime-adapter/releases)~~ (**unchanged**)
   - [x] [`modelmesh-runtime-adapter`](https://github.com/kserve/modelmesh-runtime-adapter/releases)
   - [ ] ~~[`rest-proxy`](https://github.com/kserve/rest-proxy/releases)~~ (**unchanged**)

2. Verify image tags were pushed to [DockerHub](https://hub.docker.com/u/kserve):

   **Updated**:
   - [x] [kserve/modelmesh](https://hub.docker.com/r/kserve/modelmesh/tags)
   - [x] [kserve/modelmesh-runtime-adapter](https://hub.docker.com/r/kserve/modelmesh-runtime-adapter/tags)
   
   **Unchanged**: 
   - [x] [kserve/modelmesh-minio-examples](https://hub.docker.com/r/kserve/modelmesh-minio-examples/tags)
   - [x] [kserve/rest-proxy](https://hub.docker.com/r/kserve/rest-proxy/tags)

3. Update the container image tags to the corresponding release versions for:

   **Updated**:
   - `kserve/modelmesh` -> `v0.11.0-alpha`
   - `kserve/modelmesh-controller` -> `v0.11.0-alpha`
   - `kserve/modelmesh-runtime-adapter` -> `v0.11.0-alpha`
   
   **Unchanged:**
   - `kserve/modelmesh-minio-examples` -> `v0.10.0`
   - `kserve/rest-proxy` -> `v0.10.0`

   The version tags should be updated in the following files:

   - [x] `config/default/config-defaults.yaml`:
     - [x] `kserve/modelmesh`
     - [x] `kserve/rest-proxy`
     - [x] `kserve/modelmesh-runtime-adapter`
   - [x] `config/dependencies/quickstart.yaml`:
     - [x] `kserve/modelmesh-minio-examples`
   - [x] `config/manager/kustomization.yaml`: edit the `newTag`
   - [x] `docs/component-versions.md`: update the version and component versions
   - [x] `docs/install/install-script.md`: update the `RELEASE` variable in the
         `Installation` section to the new `release-*` branch name
   - [x] `docs/quickstart.md`: update the `RELEASE` variable in the
         _"Get the latest release"_ section to the new `release-*` branch name
   - [x] `scripts/setup_user_namespaces.sh`: change the `modelmesh_release` version

