### PR TITLE
Cleanup OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,13 +1,11 @@
 approvers:
-  - animeshsingh
   - njhill
-  - pvaneck
+  - tjohnson31415
 reviewers:
-  - animeshsingh
   - njhill
-  - pvaneck
-  - tedhtchang
-  - Tomcli
-  - chinhuang007
+  - tjohnson31415
   - ckadner
   - rafvasq
+emeritus_approvers:
+  - animeshsingh  # 2023-04-12
+  - pvaneck       # 2023-04-12

--- a/OWNERS
+++ b/OWNERS
@@ -6,6 +6,7 @@ reviewers:
   - tjohnson31415
   - ckadner
   - rafvasq
+  - joerunde
 emeritus_approvers:
   - animeshsingh  # 2023-04-12
   - pvaneck       # 2023-04-12


### PR DESCRIPTION
#### Motivation

Currently, pull requests get auto-assigned `reviewers` (and `approvers`) by the @kserve-oss-bot
However, many of the reviewers and approvers are no longer active. When inactive reviewers are auto-assigned, then active contributors who could actually help with reviews are not notified about new PRs.

Similarly, the @kserve-oss-bot adds a message to PRs about who is allowed to approve PRs, which often points to inactive contributors.

#### Modifications

- Following [Kubernetes guidance](https://www.kubernetes.dev/docs/guide/owners/#cleanup), moving inactive `approvers` under `emeritus_approvers`, removing inactive contributors from list of `reviewers`
- Adding currently active contributors to the list of `reviewers`
- Removing `reviewers` who are no longer working on the project

#### Result

An updated OWNERS file. Auto-assigned reviewers are currently active.

#### Related PRs

- [ ] https://github.com/kserve/modelmesh/pull/89
- [ ] https://github.com/kserve/modelmesh-runtime-adapter/pull/44
- [ ] https://github.com/kserve/modelmesh-serving/pull/354