### PR TITLE
chore: Update TritonServer to 23.04

### DIFF
--- a/.github/workflows/fvt.yml
+++ b/.github/workflows/fvt.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Pre-pull runtime images
         run: |
           eval $(minikube -p minikube docker-env)
-          docker pull nvcr.io/nvidia/tritonserver:21.06.1-py3
+          docker pull nvcr.io/nvidia/tritonserver:23.03-py3
           docker pull seldonio/mlserver:0.5.2
           docker pull openvino/model_server:2022.2
           # docker pull pytorch/torchserve:0.7.1-cpu

--- a/.github/workflows/fvt.yml
+++ b/.github/workflows/fvt.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Pre-pull runtime images
         run: |
           eval $(minikube -p minikube docker-env)
-          docker pull nvcr.io/nvidia/tritonserver:23.03-py3
+          docker pull nvcr.io/nvidia/tritonserver:23.04-py3
           docker pull seldonio/mlserver:0.5.2
           docker pull openvino/model_server:2022.2
           # docker pull pytorch/torchserve:0.7.1-cpu

--- a/config/runtimes/kustomization.yaml
+++ b/config/runtimes/kustomization.yaml
@@ -20,7 +20,7 @@ resources:
 images:
   - name: tritonserver-2
     newName: nvcr.io/nvidia/tritonserver
-    newTag: "23.03-py3"
+    newTag: "23.04-py3"
 
   - name: mlserver-0
     newName: seldonio/mlserver

--- a/config/runtimes/kustomization.yaml
+++ b/config/runtimes/kustomization.yaml
@@ -20,7 +20,7 @@ resources:
 images:
   - name: tritonserver-2
     newName: nvcr.io/nvidia/tritonserver
-    newTag: "21.06.1-py3"
+    newTag: "23.03-py3"
 
   - name: mlserver-0
     newName: seldonio/mlserver

--- a/fvt/predictor/predictor_suite_test.go
+++ b/fvt/predictor/predictor_suite_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -55,7 +55,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	FVTClientInstance.CreateTLSSecrets()
 
 	// ensure a stable deploy state
-	WaitForStableActiveDeployState(time.Second * 30)
+	WaitForStableActiveDeployState(time.Second * 60)
 
 	return nil
 }, func(_ []byte) {

--- a/fvt/predictor/predictor_suite_test.go
+++ b/fvt/predictor/predictor_suite_test.go
@@ -55,7 +55,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	FVTClientInstance.CreateTLSSecrets()
 
 	// ensure a stable deploy state
-	WaitForStableActiveDeployState(time.Second * 60)
+	WaitForStableActiveDeployState(time.Second * 120)
 
 	return nil
 }, func(_ []byte) {

--- a/fvt/predictor/predictor_suite_test.go
+++ b/fvt/predictor/predictor_suite_test.go
@@ -55,7 +55,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	FVTClientInstance.CreateTLSSecrets()
 
 	// ensure a stable deploy state
-	WaitForStableActiveDeployState(time.Second * 120)
+	WaitForStableActiveDeployState(time.Second * 30)
 
 	return nil
 }, func(_ []byte) {

--- a/fvt/predictor/predictor_suite_test.go
+++ b/fvt/predictor/predictor_suite_test.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package predictor
 
 import (

--- a/fvt/predictor/predictor_test.go
+++ b/fvt/predictor/predictor_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -531,7 +531,7 @@ var _ = Describe("Predictor", func() {
 			inferResponse, err := FVTClientInstance.RunKfsInference(inferRequest)
 			Expect(err).To(HaveOccurred())
 			Expect(inferResponse).To(BeNil())
-			Expect(err.Error()).To(ContainSubstring("INVALID_ARGUMENT: unexpected shape for input"))
+			Expect(err.Error()).To(ContainSubstring("unexpected shape for input"))
 		})
 
 		It("should return model metadata", func() {

--- a/fvt/predictor/predictor_test.go
+++ b/fvt/predictor/predictor_test.go
@@ -467,7 +467,7 @@ var _ = Describe("Predictor", func() {
 			inferResponse, err := FVTClientInstance.RunKfsInference(inferRequest)
 			Expect(err).To(HaveOccurred())
 			Expect(inferResponse).To(BeNil())
-			Expect(err.Error()).To(ContainSubstring("INVALID_ARGUMENT: unexpected shape for input"))
+			Expect(err.Error()).To(ContainSubstring("unexpected shape for input"))
 		})
 
 		It("should return model metadata", func() {

--- a/fvt/predictor/predictor_test.go
+++ b/fvt/predictor/predictor_test.go
@@ -772,7 +772,7 @@ var _ = Describe("Predictor", func() {
 			inferResponse, err := FVTClientInstance.RunKfsInference(inferRequest)
 			Expect(err).To(HaveOccurred())
 			Log.Info(err.Error())
-			Expect(err.Error()).To(ContainSubstring("INVALID_ARGUMENT: unexpected shape for input"))
+			Expect(err.Error()).To(ContainSubstring("unexpected shape for input"))
 			Expect(inferResponse).To(BeNil())
 		})
 
@@ -840,7 +840,7 @@ var _ = Describe("Predictor", func() {
 			inferResponse, err := FVTClientInstance.RunKfsInference(inferRequest)
 			Expect(err).To(HaveOccurred())
 			Log.Info(err.Error())
-			Expect(err.Error()).To(ContainSubstring("INVALID_ARGUMENT: unexpected shape for input"))
+			Expect(err.Error()).To(ContainSubstring("unexpected shape for input"))
 			Expect(inferResponse).To(BeNil())
 		})
 	})

--- a/fvt/testdata/predictors/tf-predictor.yaml
+++ b/fvt/testdata/predictors/tf-predictor.yaml
@@ -19,7 +19,6 @@ spec:
   modelType:
     name: tensorflow
   path: fvt/tensorflow/mnist.savedmodel
-  schemaPath: fvt/tensorflow/schema/tf-schema.json
   storage:
     s3:
       secretKey: localMinIO


### PR DESCRIPTION
#### Motivation
The default Triton serving runtime in ModelMesh hasn't been updated for a while. The [latest version is 23.04](https://github.com/triton-inference-server/server/releases/tag/v2.33.0).

#### Modifications
- TritonServer image version in the default serving runtime and FVTs were updated from 21.06.1 to 23.04
- Error message(s) were updated in FVT

#### Result
- The default Triton serving runtime will now deploy using the 23.04 Triton image.
- Closes #358 
