### PR TITLE
fix: Generalizes sed and fixes dry-run cmd

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -328,7 +328,7 @@ if [[ $enable_self_signed_ca == "true" ]]; then
   sed -i.bak "1,${configMapGeneratorBeforeLine}s/^/#/g" default/kustomization.yaml
 
   # remove webhookcainjection_patch.yaml
-  sed -i.bak  's+- webhookcainjection_patch.yaml++g' default/kustomization.yaml
+  sed -i.bak '/webhookcainjection_patch.yaml/d' default/kustomization.yaml
 
   # create dummy secret 'modelmesh-webhook-server-cert'
   secretExist=$(kubectl get secret modelmesh-webhook-server-cert --ignore-not-found|wc -l)

--- a/scripts/self-signed-ca.sh
+++ b/scripts/self-signed-ca.sh
@@ -116,10 +116,10 @@ openssl x509 -extensions v3_req -req -days 365 -in ${tmpdir}/server.csr -CA ${tm
 kubectl create secret generic ${secret} \
         --from-file=tls.key=${tmpdir}/server.key \
         --from-file=tls.crt=${tmpdir}/server.crt \
-        --dry-run -o yaml |
+        --dry-run=server -o yaml |
     kubectl -n ${namespace} apply -f -
 # Webhook pod needs to be restarted so that the service reload the secret
-# http://github.com/kueflow/kubeflow/issues/3227
+# http://github.com/kubeflow/kubeflow/issues/3227
 webhookPod=$(kubectl get pods -n ${namespace} |grep ${webhookDeploymentName} |awk '{print $1;}')
 # ignore error if webhook pod does not exist
 kubectl delete pod ${webhookPod} -n ${namespace} 2>/dev/null || true


### PR DESCRIPTION
#### Motivation
I experienced a few errors when running the install script using the `--enable-self-signed-ca` flag from the recently merged #342. 

#### Modifications
- Use `sed -i.bak` to work around different versions of it, originally resulting in `sed: -i: No such file or directory` for me.
- Fix `--dry-run` error which requires a set value [(none, server, or client)](https://stackoverflow.com/questions/69531858/what-is-the-different-dry-run-opportunities)
- Fix typos

#### Result
Fixes errors associated with the `--enable-self-signed-ca` flag