### PR TITLE
doc: Remove cert flag from quickstart

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -8,8 +8,6 @@ To quickly get started using ModelMesh Serving, here is a brief guide.
 - [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) and [kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/) (v3.2.0+)
 - At least 4 vCPU and 8 GB memory. For more details, please see [here](install/README.md#deployed-components).
 
-_(Note)_ Regarding webhook certificates, there are 2 options: `cert-manager` and `self-signed-certificate`. Please refer to [install help](install/install-script.md#installation-1).
-
 ## 1. Install ModelMesh Serving
 
 ### Get the latest release
@@ -24,7 +22,7 @@ cd modelmesh-serving
 
 ```shell
 kubectl create namespace modelmesh-serving
-./scripts/install.sh --namespace-scope-mode --namespace modelmesh-serving --quickstart --enable-self-signed-ca
+./scripts/install.sh --namespace-scope-mode --namespace modelmesh-serving --quickstart
 ```
 
 This will install ModelMesh Serving in the `modelmesh-serving` namespace, along with an etcd and MinIO instances.


### PR DESCRIPTION
#### Motivation
The quickstart instructions explicitly install the latest release `v0.10` which does not include the recently added `--enable-self-signed-ca` or require info regarding webhook certificates. Following the document as-is results in an `Unknown option` error. 

#### Modifications
- Remove the `--enable-self-signed-ca` option from the quickstart guide and webhook information. 

#### Result
- Quickstart guide is functional for quick installation and deployment using the latest release `v0.10` 

Resolves #370 