### PR TITLE
Support ARM 64 bit architecture

### DIFF
--- a/controllers/modelmesh/runtime.go
+++ b/controllers/modelmesh/runtime.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package modelmesh
 
 import (
@@ -340,6 +341,9 @@ func addDomainSocketMount(rts *kserveapi.ServingRuntimeSpec, c *corev1.Container
 func (m *Deployment) addPassThroughPodFieldsToDeployment(deployment *appsv1.Deployment) error {
 	rts := m.SRSpec
 	// these fields map directly to pod spec fields
+	// supported architectures are "amd64" and "arm64", "ppc64le"
+	// and "s390x" are not supported by tensorflow
+	// (https://github.com/kserve/modelmesh-runtime-adapter/pull/38#discussion_r1156749259)
 	deployment.Spec.Template.Spec.NodeSelector = rts.NodeSelector
 	deployment.Spec.Template.Spec.Tolerations = rts.Tolerations
 	archNodeSelector := corev1.NodeSelectorTerm{
@@ -347,7 +351,7 @@ func (m *Deployment) addPassThroughPodFieldsToDeployment(deployment *appsv1.Depl
 			{
 				Key:      "kubernetes.io/arch",
 				Operator: corev1.NodeSelectorOpIn,
-				Values:   []string{"amd64"},
+				Values:   []string{"amd64", "arm64"},
 			},
 		},
 	}

--- a/controllers/testdata/servingruntime_controller.golden
+++ b/controllers/testdata/servingruntime_controller.golden
@@ -37,6 +37,7 @@ spec:
                 operator: In
                 values:
                 - amd64
+                - arm64
       containers:
       - command:
         - /opt/app/mlserver-adapter
@@ -290,6 +291,7 @@ spec:
                 operator: In
                 values:
                 - amd64
+                - arm64
       containers:
       - command:
         - /opt/app/mlserver-adapter
@@ -539,6 +541,7 @@ spec:
                 operator: In
                 values:
                 - amd64
+                - arm64
       containers:
       - env:
         - name: REST_PROXY_LISTEN_PORT
@@ -810,6 +813,7 @@ spec:
                 operator: In
                 values:
                 - amd64
+                - arm64
       containers:
       - command:
         - /opt/app/mlserver-adapter
@@ -1056,6 +1060,7 @@ spec:
                 operator: In
                 values:
                 - amd64
+                - arm64
       containers:
       - command:
         - /opt/app/ovms-adapter
@@ -1294,6 +1299,7 @@ spec:
                 operator: In
                 values:
                 - amd64
+                - arm64
       containers:
       - command:
         - /opt/app/torchserve-adapter
@@ -1535,6 +1541,7 @@ spec:
                 operator: In
                 values:
                 - amd64
+                - arm64
       containers:
       - command:
         - /opt/app/triton-adapter
@@ -1791,6 +1798,7 @@ spec:
                 operator: In
                 values:
                 - amd64
+                - arm64
       containers:
       - env:
         - name: MODEL_DIRECTORY_PATH


### PR DESCRIPTION
## Issue Addressed by this PR

Quickstart deployment of an `InferenceService` fails on Macs with M1 chip. The `modelmesh-serving-mlserver-0.x` pod does not deploy because of an affinity restriction to `amd64`.

```
Events:
  Type     Reason            Age   From               Message
  ----     ------            ----  ----               -------
  Warning  FailedScheduling  17s   default-scheduler  0/1 nodes are available: 1 node(s) didn't match Pod's node affinity/selector. preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling.
```

```
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
            - matchExpressions:
              - key: kubernetes.io/arch
                operator: In
                values:
                - amd64
```

**Source**:

https://github.com/kserve/modelmesh-serving/blob/1b3d30ac089d729bfe59e91c395a977e347aaada/controllers/modelmesh/runtime.go#L345-L353


## Proposed Fix

Support `arm64` arch for Node affinity. The [`modelmesh-runtime-adapter`](https://hub.docker.com/r/kserve/modelmesh-runtime-adapter/tags) supports `amd64` and `arm64` as pointed out [here](https://github.com/kserve/modelmesh-runtime-adapter/pull/38#discussion_r1156749259).

## Modifications

```Go
	archNodeSelector := corev1.NodeSelectorTerm{
		MatchExpressions: []corev1.NodeSelectorRequirement{
			{
				Key:      "kubernetes.io/arch",
				Operator: corev1.NodeSelectorOpIn,
				Values:   []string{"amd64", "arm64"},
			},
		},
	}
```

## Result

Successful deployment on `arm64` architecture nodes.

## Related Issues

- #314 
- https://github.com/kserve/modelmesh/pull/92
