### PR TITLE
release: Update image tags for v0.11.0-rc0

### DIFF
--- a/config/default/config-defaults.yaml
+++ b/config/default/config-defaults.yaml
@@ -16,7 +16,7 @@ podsPerRuntime: 2
 headlessService: true
 modelMeshImage:
   name: kserve/modelmesh
-  tag: latest
+  tag: v0.11.0-rc0
 modelMeshResources:
   requests:
     cpu: "300m"
@@ -29,7 +29,7 @@ restProxy:
   port: 8008
   image:
     name: kserve/rest-proxy
-    tag: latest
+    tag: v0.11.0-rc0
   resources:
     requests:
       cpu: "50m"
@@ -39,7 +39,7 @@ restProxy:
       memory: "512Mi"
 storageHelperImage:
   name: kserve/modelmesh-runtime-adapter
-  tag: latest
+  tag: v0.11.0-rc0
   command: ["/opt/app/puller"]
 storageHelperResources:
   requests:

--- a/config/dependencies/quickstart.yaml
+++ b/config/dependencies/quickstart.yaml
@@ -110,7 +110,7 @@ spec:
             - name: MINIO_SECRET_KEY
               value: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
           # image: quay.io/cloudservices/minio:latest
-          image: kserve/modelmesh-minio-examples:latest
+          image: kserve/modelmesh-minio-examples:v0.11.0-rc0
           name: minio
 ---
 apiVersion: v1

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -18,4 +18,4 @@ images:
   - name: modelmesh-controller
     newName: kserve/modelmesh-controller
     ## NOTE THIS SHOULD BE REPLACED WITH LATEST CONTROLLER IMAGE TAG
-    newTag: latest
+    newTag: v0.11.0-rc0

--- a/docs/component-versions.md
+++ b/docs/component-versions.md
@@ -1,8 +1,8 @@
 # Component versions
 
-The following table shows the component versions for the latest modelmesh-serving release (v0.10.0).
+The following table shows the component versions for the latest modelmesh-serving release (v0.11.0-rc0).
 | Component | Description | Upstream Revision |
 | - | - | - |
-| ModelMesh | Serves as a general-purpose model serving management/routing layer | [v0.10.0](https://github.com/kserve/modelmesh/tree/v0.10.0) |
-| ModelMesh Runtime Adapter | Contains the unified puller/runtime-adapter image | [v0.10.0](https://github.com/kserve/modelmesh-runtime-adapter/tree/v0.10.0) |
-| REST Proxy | Supports inference requests using KServe V2 REST Predict Protocol | [v0.10.0](https://github.com/kserve/rest-proxy/tree/v0.10.0) |
+| ModelMesh | Serves as a general-purpose model serving management/routing layer | [v0.11.0-rc0](https://github.com/kserve/modelmesh/tree/v0.11.0-rc0) |
+| ModelMesh Runtime Adapter | Contains the unified puller/runtime-adapter image | [v0.11.0-rc0](https://github.com/kserve/modelmesh-runtime-adapter/tree/v0.11.0-rc0) |
+| REST Proxy | Supports inference requests using KServe V2 REST Predict Protocol | [v0.11.0-rc0](https://github.com/kserve/rest-proxy/tree/v0.11.0-rc0) |

--- a/docs/install/install-script.md
+++ b/docs/install/install-script.md
@@ -43,7 +43,7 @@ A secret named `model-serving-etcd` will be created and passed to the controller
 Install the latest release of [modelmesh-serving](https://github.com/kserve/modelmesh-serving/releases/latest) by first cloning the corresponding release branch:
 
 ```shell
-RELEASE=release-0.10
+RELEASE=release-0.11
 git clone -b $RELEASE --depth 1 --single-branch https://github.com/kserve/modelmesh-serving.git
 cd modelmesh-serving
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -13,7 +13,7 @@ To quickly get started using ModelMesh Serving, here is a brief guide.
 ### Get the latest release
 
 ```shell
-RELEASE=release-0.10
+RELEASE=release-0.11
 git clone -b $RELEASE --depth 1 --single-branch https://github.com/kserve/modelmesh-serving.git
 cd modelmesh-serving
 ```

--- a/scripts/setup_user_namespaces.sh
+++ b/scripts/setup_user_namespaces.sh
@@ -31,7 +31,7 @@ EOF
 
 ctrl_ns="modelmesh-serving"
 user_ns_array=()
-modelmesh_release="v0.10.0"       # The latest release is the default
+modelmesh_release="v0.11.0-rc0"       # The latest release is the default
 create_storage_secret=false
 deploy_serving_runtimes=false
 dev_mode=false                    # Set to true to use locally cloned files instead of from a release


### PR DESCRIPTION
#### Release checklist

**Create release tags (`v0.11.0-rc0`) in these repositories:**
 - [x] [`modelmesh`](https://github.com/kserve/modelmesh/releases)
 - [x] [`modelmesh-runtime-adapter`](https://github.com/kserve/modelmesh-runtime-adapter/releases)
 - [x] [`rest-proxy`](https://github.com/kserve/rest-proxy/releases)

**Verify image tags got pushed to [DockerHub](https://hub.docker.com/u/kserve):**
 - [x] [kserve/modelmesh](https://hub.docker.com/r/kserve/modelmesh/tags)
 - [x] [kserve/modelmesh-minio-examples](https://hub.docker.com/r/kserve/modelmesh-minio-examples/tags)
 - [x] [kserve/modelmesh-runtime-adapter](https://hub.docker.com/r/kserve/modelmesh-runtime-adapter/tags)
 - [x] [kserve/rest-proxy](https://hub.docker.com/r/kserve/rest-proxy/tags)

**Update versions in the following files:**
 - [x] `config/default/config-defaults.yaml`: edit the images tags for ...
     - [x] `kserve/modelmesh`
     - [x] `kserve/rest-proxy`
     - [x] `kserve/modelmesh-runtime-adapter` 
 - [x] `config/dependencies/quickstart.yaml`: change the `kserve/modelmesh-minio-examples` image tag to use the pinned version
 - [x] `config/manager/kustomization.yaml`: edit the `newTag`
 - [x] `docs/component-versions.md`: update the version and component versions
 - [x] `docs/install/install-script.md`: update the `RELEASE` variable in the `Installation` section to the new `release-*` branch name
 - [x] `docs/quickstart.md`: update the `RELEASE` variable in the _"Get the latest release"_ section to the new `release-*` branch name
 - [x] `scripts/setup_user_namespaces.sh`: change the `modelmesh_release` version


**Compare to tag updates for `v0.10.0-rc0` release:**
- https://github.com/kserve/modelmesh-serving/pull/296