### PR TITLE
doc: Update docs with v0.11.0-rc0

### DIFF
--- a/docs/component-versions.md
+++ b/docs/component-versions.md
@@ -3,6 +3,6 @@
 The following table shows the component versions for the latest modelmesh-serving release (v0.10.0).
 | Component | Description | Upstream Revision |
 | - | - | - |
-| ModelMesh | Serves as a general-purpose model serving management/routing layer | [v0.10.0](https://github.com/kserve/modelmesh/tree/v0.10.0) |
-| ModelMesh Runtime Adapter | Contains the unified puller/runtime-adapter image | [v0.10.0](https://github.com/kserve/modelmesh-runtime-adapter/tree/v0.10.0) |
-| REST Proxy | Supports inference requests using KServe V2 REST Predict Protocol | [v0.10.0](https://github.com/kserve/rest-proxy/tree/v0.10.0) |
+| ModelMesh | Serves as a general-purpose model serving management/routing layer | [v0.11.0-rc0](https://github.com/kserve/modelmesh/tree/v0.11.0-rc0) |
+| ModelMesh Runtime Adapter | Contains the unified puller/runtime-adapter image | [v0.11.0-rc0](https://github.com/kserve/modelmesh-runtime-adapter/tree/v0.11.0-rc0) |
+| REST Proxy | Supports inference requests using KServe V2 REST Predict Protocol | [v0.11.0-rc0](https://github.com/kserve/rest-proxy/tree/v0.11.0-rc0) |

--- a/docs/install/install-script.md
+++ b/docs/install/install-script.md
@@ -43,7 +43,7 @@ A secret named `model-serving-etcd` will be created and passed to the controller
 Install the latest release of [modelmesh-serving](https://github.com/kserve/modelmesh-serving/releases/latest) by first cloning the corresponding release branch:
 
 ```shell
-RELEASE=release-0.10
+RELEASE=release-0.11
 git clone -b $RELEASE --depth 1 --single-branch https://github.com/kserve/modelmesh-serving.git
 cd modelmesh-serving
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -13,7 +13,7 @@ To quickly get started using ModelMesh Serving, here is a brief guide.
 ### Get the latest release
 
 ```shell
-RELEASE=release-0.10
+RELEASE=release-0.11
 git clone -b $RELEASE --depth 1 --single-branch https://github.com/kserve/modelmesh-serving.git
 cd modelmesh-serving
 ```

--- a/scripts/setup_user_namespaces.sh
+++ b/scripts/setup_user_namespaces.sh
@@ -31,7 +31,7 @@ EOF
 
 ctrl_ns="modelmesh-serving"
 user_ns_array=()
-modelmesh_release="v0.10.0"       # The latest release is the default
+modelmesh_release="v0.11.0-rc0"       # The latest release is the default
 create_storage_secret=false
 deploy_serving_runtimes=false
 dev_mode=false                    # Set to true to use locally cloned files instead of from a release


### PR DESCRIPTION
**TODO: Update to v0.11.0**

--- 

Updates docs in `main`, related to #390 

As per [step 5 in the release process](https://github.com/kserve/modelmesh-serving/blob/main/docs/release-process.md#update-release-tags):
- [x]  `docs/component-versions.md`
- [x]  `docs/quickstart.md`
- [x]  `docs/install/install-script.md`
- [x]  `scripts/setup_user_namespaces.sh`