### PR TITLE
Updated /controllers/predictor_controller.go

### DIFF
--- a/controllers/predictor_controller.go
+++ b/controllers/predictor_controller.go
@@ -390,6 +390,7 @@ func concreteModelName(predictor *api.Predictor, sourceId string) string {
 // "There are no running instances that meet the label requirements of type _default: [_no_runtime]"
 const noHomeMessage string = "There are no running instances that meet the label requirements of type "
 
+//If this function setting the error, "RuntimeNotRecognize" should've to be controlled before "RuntimeUnhealthy". So, order changed.
 func decodeModelState(status *mmeshapi.ModelStatusInfo) (api.ModelState, api.FailureReason, string) {
 	reason := api.FailureReason("")
 	msg := ""
@@ -406,12 +407,16 @@ func decodeModelState(status *mmeshapi.ModelStatusInfo) (api.ModelState, api.Fai
 	if !strings.HasPrefix(msg, noHomeMessage) {
 		return api.FailedToLoad, api.ModelLoadFailed, msg
 	}
+        if msg[len(noHomeMessage):len(noHomeMessage)+3] == "rt:" {
+                return api.FailedToLoad, api.RuntimeNotRecognized, "Specified runtime name not recognized"
+        }
+
 	if !strings.HasSuffix(msg, "["+modelmesh.ModelTypeLabelThatNoRuntimeSupports+"]") {
 		return api.Loading, api.RuntimeUnhealthy, "Waiting for supporting runtime Pod to become available"
 	}
-	if msg[len(noHomeMessage):len(noHomeMessage)+3] == "rt:" {
-		return api.FailedToLoad, api.RuntimeNotRecognized, "Specified runtime name not recognized"
-	}
+	//if msg[len(noHomeMessage):len(noHomeMessage)+3] == "rt:" {
+	//	return api.FailedToLoad, api.RuntimeNotRecognized, "Specified runtime name not recognized"
+	//}
 	return api.FailedToLoad, api.NoSupportingRuntime, "No ServingRuntime supports specified model type and/or protocol"
 }
 


### PR DESCRIPTION
#### Motivation
[#279 ](https://github.com/kserve/modelmesh-serving/issues/279)
#### Modifications
Updated check order on "decodeModelState" function in /controllers/predictor_controller.go
#### Result
According to this [bug](https://github.com/kserve/modelmesh-serving/issues/279), I think the reason why InferenceService's state is not updated correctly is because the error is not defined correctly. If there is no ServingRuntime defined with the specified runtime name, reason should be: "RuntimeNotRecognize". The main cause of the error is "RuntimeNotRecognize", but it satisfies the conditions for the "RuntimeUnhealthy" error, and the error is defined as "RuntimeUnhealthy" because this check is done before the other error. The mentioned check is done in "decodeModelState" function in /controllers/predictor_controller.go. I made a small change in the function that I thought the error was detected, but I could not try the change. Because my computer has a shortage of ram and I'm having trouble with images. But if my idea is approved, I can solve my ram related issue and continue development.
