### PR TITLE
chore: Add manual trigger to run build/push action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,14 @@
 name: Build
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
       - 'release-[0-9].[0-9]+'
     tags:
       - 'v*'
-    paths-ignore:
+    paths-ignore:    
       - '.github/**'
       - '.tekton/**'
       - '**.md'
@@ -53,7 +54,7 @@ jobs:
           driver-opts: network=host
 
       - name: Login to DockerHub
-        if: github.event_name == 'push'
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USER }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
       - 'release-[0-9].[0-9]+'
     tags:
       - 'v*'
-    paths-ignore:    
+    paths-ignore:
       - '.github/**'
       - '.tekton/**'
       - '**.md'


### PR DESCRIPTION
#### Motivation

Sometimes the GitHub action to push images does not get triggered despite apparently all filter conditions being met.

#### Modifications

Add [`on: workflow_dispatch`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch) to build/push action workflow.

To trigger a workflow in a repository, the user has to be a collaborator with Write permission in the repository. External users can’t trigger workflows in the repository.

#### Result

TBD