### PR TITLE
release: Update ModelMesh image tags to v0.11.0

### DIFF
--- a/.github/workflows/fvt.yml
+++ b/.github/workflows/fvt.yml
@@ -112,11 +112,11 @@ jobs:
           docker pull seldonio/mlserver:1.3.2
           docker pull openvino/model_server:2022.2
           # docker pull pytorch/torchserve:0.7.1-cpu
-          docker pull kserve/modelmesh:v0.11.0-rc1
-          docker pull kserve/modelmesh-minio-dev-examples:v0.11.0-rc1
-          docker pull kserve/modelmesh-minio-examples:v0.11.0-rc1
-          docker pull kserve/modelmesh-runtime-adapter:v0.11.0-rc1
-          docker pull kserve/rest-proxy:v0.11.0-rc1
+          docker pull kserve/modelmesh:v0.11.0
+          docker pull kserve/modelmesh-minio-dev-examples:v0.11.0
+          docker pull kserve/modelmesh-minio-examples:v0.11.0
+          docker pull kserve/modelmesh-runtime-adapter:v0.11.0
+          docker pull kserve/rest-proxy:v0.11.0
 
       - name: Check installation
         run: |

--- a/config/default/config-defaults.yaml
+++ b/config/default/config-defaults.yaml
@@ -16,7 +16,7 @@ podsPerRuntime: 2
 headlessService: true
 modelMeshImage:
   name: kserve/modelmesh
-  tag: v0.11.0-rc1
+  tag: v0.11.0
 modelMeshResources:
   requests:
     cpu: "300m"
@@ -29,7 +29,7 @@ restProxy:
   port: 8008
   image:
     name: kserve/rest-proxy
-    tag: v0.11.0-rc1
+    tag: v0.11.0
   resources:
     requests:
       cpu: "50m"
@@ -39,7 +39,7 @@ restProxy:
       memory: "512Mi"
 storageHelperImage:
   name: kserve/modelmesh-runtime-adapter
-  tag: v0.11.0-rc1
+  tag: v0.11.0
   command: ["/opt/app/puller"]
 storageHelperResources:
   requests:

--- a/config/dependencies/fvt.yaml
+++ b/config/dependencies/fvt.yaml
@@ -108,7 +108,7 @@ spec:
               value: AKIAIOSFODNN7EXAMPLE
             - name: MINIO_SECRET_KEY
               value: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-          image: kserve/modelmesh-minio-dev-examples:v0.11.0-rc1
+          image: kserve/modelmesh-minio-dev-examples:v0.11.0
           name: minio
 ---
 apiVersion: v1
@@ -171,7 +171,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: "copy-pod"
-          image: kserve/modelmesh-minio-examples:v0.11.0-rc1
+          image: kserve/modelmesh-minio-examples:v0.11.0
           securityContext:
             runAsUser: 0
             allowPrivilegeEscalation: false

--- a/config/dependencies/quickstart.yaml
+++ b/config/dependencies/quickstart.yaml
@@ -110,7 +110,7 @@ spec:
             - name: MINIO_SECRET_KEY
               value: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
           # image: quay.io/cloudservices/minio:latest
-          image: kserve/modelmesh-minio-examples:v0.11.0-rc1
+          image: kserve/modelmesh-minio-examples:v0.11.0
           name: minio
 ---
 apiVersion: v1

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -18,4 +18,4 @@ images:
   - name: modelmesh-controller
     newName: kserve/modelmesh-controller
     ## NOTE THIS SHOULD BE REPLACED WITH LATEST CONTROLLER IMAGE TAG
-    newTag: v0.11.0-rc1
+    newTag: v0.11.0

--- a/docs/component-versions.md
+++ b/docs/component-versions.md
@@ -1,8 +1,8 @@
 # Component versions
 
-The following table shows the component versions for the latest modelmesh-serving release (v0.11.0-rc1).
+The following table shows the component versions for the latest modelmesh-serving release (v0.11.0).
 | Component | Description | Upstream Revision |
 | - | - | - |
-| ModelMesh | Serves as a general-purpose model serving management/routing layer | [v0.11.0-rc1](https://github.com/kserve/modelmesh/tree/v0.11.0-rc1) |
-| ModelMesh Runtime Adapter | Contains the unified puller/runtime-adapter image | [v0.11.0-rc1](https://github.com/kserve/modelmesh-runtime-adapter/tree/v0.11.0-rc1) |
-| REST Proxy | Supports inference requests using KServe V2 REST Predict Protocol | [v0.11.0-rc1](https://github.com/kserve/rest-proxy/tree/v0.11.0-rc1) |
+| ModelMesh | Serves as a general-purpose model serving management/routing layer | [v0.11.0](https://github.com/kserve/modelmesh/tree/v0.11.0) |
+| ModelMesh Runtime Adapter | Contains the unified puller/runtime-adapter image | [v0.11.0](https://github.com/kserve/modelmesh-runtime-adapter/tree/v0.11.0) |
+| REST Proxy | Supports inference requests using KServe V2 REST Predict Protocol | [v0.11.0](https://github.com/kserve/rest-proxy/tree/v0.11.0) |

--- a/docs/install/install-script.md
+++ b/docs/install/install-script.md
@@ -40,7 +40,7 @@ A secret named `model-serving-etcd` will be created and passed to the controller
 
 ## Installation
 
-Install the `v0.11.0-rc1` release of [modelmesh-serving](https://github.com/kserve/modelmesh-serving/releases/v0.11.0-rc1) by first cloning the corresponding release branch:
+Install the `v0.11.0` release of [modelmesh-serving](https://github.com/kserve/modelmesh-serving/releases/v0.11.0) by first cloning the corresponding release branch:
 
 ```shell
 RELEASE="release-0.11"

--- a/scripts/setup_user_namespaces.sh
+++ b/scripts/setup_user_namespaces.sh
@@ -31,7 +31,7 @@ EOF
 
 ctrl_ns="modelmesh-serving"
 user_ns_array=()
-modelmesh_release="v0.11.0-rc1"   # The latest release is the default
+modelmesh_release="v0.11.0"   # The latest release is the default
 create_storage_secret=false
 deploy_serving_runtimes=false
 dev_mode=false                    # Set to true to use locally cloned files instead of from a release


### PR DESCRIPTION
#### Release checklist

**Create release tags (`v0.11.0`) in these repositories:**
 - [x] [`modelmesh`](https://github.com/kserve/modelmesh/releases)
 - [x] [`modelmesh-runtime-adapter`](https://github.com/kserve/modelmesh-runtime-adapter/releases)
 - [x] [`rest-proxy`](https://github.com/kserve/rest-proxy/releases)

**Verify image tags got pushed to [DockerHub](https://hub.docker.com/u/kserve):**
 - [x] [kserve/modelmesh](https://hub.docker.com/r/kserve/modelmesh/tags)
 - [x] [kserve/modelmesh-minio-examples](https://hub.docker.com/r/kserve/modelmesh-minio-examples/tags)
 - [x] [kserve/modelmesh-runtime-adapter](https://hub.docker.com/r/kserve/modelmesh-runtime-adapter/tags)
 - [x] [kserve/rest-proxy](https://hub.docker.com/r/kserve/rest-proxy/tags)

**Update versions in the following files:**
 - [x] `config/default/config-defaults.yaml`: edit the images tags for ...
     - [x] `kserve/modelmesh`
     - [x] `kserve/rest-proxy`
     - [x] `kserve/modelmesh-runtime-adapter` 
 - [x] `config/dependencies/quickstart.yaml`: change the `kserve/modelmesh-minio-examples` image tag to use the pinned version
 - [x] `config/manager/kustomization.yaml`: edit the `newTag`
 - [x] `docs/component-versions.md`: update the version and component versions
 - [x] `docs/install/install-script.md`: update the `RELEASE` variable in the `Installation` section to the new `release-*` branch name
 - [x] `docs/quickstart.md`: update the `RELEASE` variable in the _"Get the latest release"_ section to the new `release-*` branch name
 - [x] `scripts/setup_user_namespaces.sh`: change the `modelmesh_release` version