### PR TITLE
doc: Update docs for release v0.11.0

### DIFF
--- a/.github/workflows/fvt.yml
+++ b/.github/workflows/fvt.yml
@@ -112,9 +112,10 @@ jobs:
           docker pull seldonio/mlserver:1.3.2
           docker pull openvino/model_server:2022.2
           # docker pull pytorch/torchserve:0.7.1-cpu
-          docker pull kserve/modelmesh-runtime-adapter
-          docker pull kserve/rest-proxy
-          docker pull kserve/modelmesh
+          docker pull kserve/modelmesh:latest
+          docker pull kserve/modelmesh-minio-dev-examples:latest
+          docker pull kserve/modelmesh-runtime-adapter:latest
+          docker pull kserve/rest-proxy:latest
 
       - name: Check installation
         run: |

--- a/.github/workflows/fvt.yml
+++ b/.github/workflows/fvt.yml
@@ -114,6 +114,7 @@ jobs:
           # docker pull pytorch/torchserve:0.7.1-cpu
           docker pull kserve/modelmesh:latest
           docker pull kserve/modelmesh-minio-dev-examples:latest
+          docker pull kserve/modelmesh-minio-examples:latest
           docker pull kserve/modelmesh-runtime-adapter:latest
           docker pull kserve/rest-proxy:latest
 

--- a/controllers/modelmesh/modelmesh.go
+++ b/controllers/modelmesh/modelmesh.go
@@ -261,24 +261,24 @@ func (m *Deployment) addMMEnvVars(deployment *appsv1.Deployment) error {
 	}
 
 	if m.EnableAccessLogging {
-		// See https://github.com/kserve/modelmesh/blob/v0.10.0/src/main/java/com/ibm/watson/modelmesh/ModelMeshEnvVars.java#L50
+		// See https://github.com/kserve/modelmesh/blob/v0.11.0/src/main/java/com/ibm/watson/modelmesh/ModelMeshEnvVars.java#L55
 		if err := setEnvironmentVar(ModelMeshContainerName, "MM_LOG_EACH_INVOKE", "true", deployment); err != nil {
 			return err
 		}
 	}
 
 	if m.GrpcMaxMessageSize > 0 {
-		// See https://github.com/kserve/modelmesh/blob/v0.10.0/src/main/java/com/ibm/watson/modelmesh/ModelMeshEnvVars.java#L34
+		// See https://github.com/kserve/modelmesh/blob/v0.11.0/src/main/java/com/ibm/watson/modelmesh/ModelMeshEnvVars.java#L38
 		if err := setEnvironmentVar(ModelMeshContainerName, "MM_SVC_GRPC_MAX_MSG_SIZE", strconv.Itoa(m.GrpcMaxMessageSize), deployment); err != nil {
 			return err
 		}
 	}
 
-	// See https://github.com/kserve/modelmesh/blob/v0.10.0/src/main/java/com/ibm/watson/modelmesh/ModelMeshEnvVars.java#L27
+	// See https://github.com/kserve/modelmesh/blob/v0.11.0/src/main/java/com/ibm/watson/modelmesh/ModelMeshEnvVars.java#L31
 	if err := setEnvironmentVar(ModelMeshContainerName, "MM_KVSTORE_PREFIX", ModelMeshEtcdPrefix, deployment); err != nil {
 		return err
 	}
-	// See https://github.com/kserve/modelmesh/blob/v0.10.0/src/main/java/com/ibm/watson/modelmesh/ModelMeshEnvVars.java#L63
+	// See https://github.com/kserve/modelmesh/blob/v0.11.0/src/main/java/com/ibm/watson/modelmesh/ModelMeshEnvVars.java#L68
 	if err := setEnvironmentVar(ModelMeshContainerName, "MM_DEFAULT_VMODEL_OWNER", m.DefaultVModelOwner, deployment); err != nil {
 		return err
 	}

--- a/docs/component-versions.md
+++ b/docs/component-versions.md
@@ -1,8 +1,8 @@
 # Component versions
 
-The following table shows the component versions for the latest modelmesh-serving release (v0.10.0).
+The following table shows the component versions for the latest modelmesh-serving release (v0.11.0).
 | Component | Description | Upstream Revision |
 | - | - | - |
-| ModelMesh | Serves as a general-purpose model serving management/routing layer | [v0.10.0](https://github.com/kserve/modelmesh/tree/v0.10.0) |
-| ModelMesh Runtime Adapter | Contains the unified puller/runtime-adapter image | [v0.10.0](https://github.com/kserve/modelmesh-runtime-adapter/tree/v0.10.0) |
-| REST Proxy | Supports inference requests using KServe V2 REST Predict Protocol | [v0.10.0](https://github.com/kserve/rest-proxy/tree/v0.10.0) |
+| ModelMesh | Serves as a general-purpose model serving management/routing layer | [v0.11.0](https://github.com/kserve/modelmesh/tree/v0.11.0) |
+| ModelMesh Runtime Adapter | Contains the unified puller/runtime-adapter image | [v0.11.0](https://github.com/kserve/modelmesh-runtime-adapter/tree/v0.11.0) |
+| REST Proxy | Supports inference requests using KServe V2 REST Predict Protocol | [v0.11.0](https://github.com/kserve/rest-proxy/tree/v0.11.0) |

--- a/docs/install/install-script.md
+++ b/docs/install/install-script.md
@@ -40,17 +40,22 @@ A secret named `model-serving-etcd` will be created and passed to the controller
 
 ## Installation
 
-Install the latest release of [modelmesh-serving](https://github.com/kserve/modelmesh-serving/releases/latest) by first cloning the corresponding release branch:
+<!-- Remove the following note on the `release-*` branch -->
+To install the most recent _stable release_ of [modelmesh-serving](https://github.com/kserve/modelmesh-serving/releases/latest)
+follow the [Installation instructions](https://github.com/kserve/modelmesh-serving/blob/release-0.11/docs/install/install-script.md) for version `v0.11.0`.
 
+Start by cloning the [modelmesh-serving](https://github.com/kserve/modelmesh-serving.git) repository:
+
+<!-- Replace with RELEASE="release-0.11" on the `release-*` branch -->
 ```shell
-RELEASE=release-0.10
+RELEASE="main"
 git clone -b $RELEASE --depth 1 --single-branch https://github.com/kserve/modelmesh-serving.git
 cd modelmesh-serving
 ```
 
 Run the script to install ModelMesh Serving CRDs, controller, and built-in runtimes into the specified Kubernetes namespaces, after reviewing the command line flags below.
 
-A Kubernetes `--namespace` is required, which must already exist. You must also have cluster-admin authority and cluster access must be configured prior to running the install script.
+A Kubernetes `--namespace` is required, which must already exist. You must also have cluster-admin authority and cluster access must be configured prior to running the installation script.
 
 A list of Kubernetes namespaces `--user-namespaces` is optional to enable user namespaces for ModelMesh Serving. The script will skip the namespaces which don't already exist.
 

--- a/docs/install/install-script.md
+++ b/docs/install/install-script.md
@@ -41,12 +41,14 @@ A secret named `model-serving-etcd` will be created and passed to the controller
 ## Installation
 
 <!-- Remove the following note on the `release-*` branch -->
+
 To install the most recent _stable release_ of [modelmesh-serving](https://github.com/kserve/modelmesh-serving/releases/latest)
 follow the [Installation instructions](https://github.com/kserve/modelmesh-serving/blob/release-0.11/docs/install/install-script.md) for version `v0.11.0`.
 
 Start by cloning the [modelmesh-serving](https://github.com/kserve/modelmesh-serving.git) repository:
 
 <!-- Replace with RELEASE="release-0.11" on the `release-*` branch -->
+
 ```shell
 RELEASE="main"
 git clone -b $RELEASE --depth 1 --single-branch https://github.com/kserve/modelmesh-serving.git

--- a/docs/production-use/README.md
+++ b/docs/production-use/README.md
@@ -9,6 +9,6 @@
 #### Version support
 
 | Platform         | Minimum version |
-| ---------------- | :-------------: |
-| Kubernetes       |      1.16       |
+|------------------|:---------------:|
+| Kubernetes       |      1.23       |
 | CPU architecture |     x86_64      |

--- a/docs/production-use/README.md
+++ b/docs/production-use/README.md
@@ -9,6 +9,6 @@
 #### Version support
 
 | Platform         | Minimum version |
-|------------------|:---------------:|
+| ---------------- | :-------------: |
 | Kubernetes       |      1.23       |
 | CPU architecture |     x86_64      |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -3,6 +3,7 @@
 To quickly get started using ModelMesh Serving, here is a brief guide.
 
 <!-- Remove the following note on the `release-*` branch -->
+
 > **Note**: This document describes how to install the _latest unreleased_ version of ModelMesh for developers and early adopters. To install the most recent _stable release_, please follow the [Quick Start Guide for version 0.11](https://github.com/kserve/modelmesh-serving/blob/release-0.11/docs/quickstart.md).
 
 ## Prerequisites
@@ -16,6 +17,7 @@ To quickly get started using ModelMesh Serving, here is a brief guide.
 ### Clone the ModelMesh repository
 
 <!-- Replace with RELEASE="release-0.11" on the `release-*` branch -->
+
 ```shell
 RELEASE="main"
 git clone -b $RELEASE --depth 1 --single-branch https://github.com/kserve/modelmesh-serving.git

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,29 +2,31 @@
 
 To quickly get started using ModelMesh Serving, here is a brief guide.
 
-> **Note**: To install the latest stable release, please follow the [Quick Start Guide for version 0.11](https://github.com/kserve/modelmesh-serving/blob/release-0.11/docs/quickstart.md).
+<!-- Remove the following note on the `release-*` branch -->
+> **Note**: This document describes how to install the _latest unreleased_ version of ModelMesh for developers and early adopters. To install the most recent _stable release_, please follow the [Quick Start Guide for version 0.11](https://github.com/kserve/modelmesh-serving/blob/release-0.11/docs/quickstart.md).
 
 ## Prerequisites
 
-- A Kubernetes cluster v 1.16+ with cluster administrative privileges
-- [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) and [kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/) (v3.2.0+)
+- A Kubernetes cluster v1.23+ with cluster administrative privileges
+- [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) and [kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/) (v4.0+)
 - At least 4 vCPU and 8 GB memory. For more details, please see [here](install/README.md#deployed-components).
 
 ## 1. Install ModelMesh Serving
 
-### Get the latest release
+### Clone the ModelMesh repository
 
+<!-- Replace with RELEASE="release-0.11" on the `release-*` branch -->
 ```shell
-RELEASE=release-0.10
+RELEASE="main"
 git clone -b $RELEASE --depth 1 --single-branch https://github.com/kserve/modelmesh-serving.git
 cd modelmesh-serving
 ```
 
-### Run install script
+### Run the installation script
 
 ```shell
 kubectl create namespace modelmesh-serving
-./scripts/install.sh --namespace-scope-mode --namespace modelmesh-serving --quickstart
+./scripts/install.sh --namespace-scope-mode --namespace modelmesh-serving --quickstart --enable-self-signed-ca
 ```
 
 This will install ModelMesh Serving in the `modelmesh-serving` namespace, along with an etcd and MinIO instances.
@@ -34,7 +36,7 @@ Eventually after running this script, you should see a `Successfully installed M
 
 To see more details about installation, click [here](./install/install-script.md).
 
-### Verify installation
+### Verify the installation
 
 Check that the pods are running:
 
@@ -270,7 +272,7 @@ This should give you a response like the following:
 
 To see more detailed instructions and information, click [here](./predictors/run-inference.md).
 
-## 4. (Optional) Deleting your ModelMesh Serving installation
+## 4. (Optional) Delete the ModelMesh Serving installation
 
 To delete all ModelMesh Serving resources that were installed, run the following
 command from the root of the project:

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -69,8 +69,8 @@ version numbers. Most IDEs support searching an entire project using `command`-`
 
 Some of the steps below need to be performed at least twice:
 
-- at least once for the release candidate(s) (`v0.10.0-rc0`, `v0.10.0-rc1`, ...) and
-- once more for the actual release (`v0.10.0`).
+- at least once for the release candidate(s) (`v0.11.0-rc0`, `v0.11.0-rc1`, ...) and
+- once more for the actual release (`v0.11.0`).
 
 While creating a pre-release is not technically required, it is considered good
 practice. It allows other stakeholders to deploy and test the designated release,
@@ -98,8 +98,8 @@ with KServe.
    - [ ] [kserve/modelmesh-runtime-adapter](https://hub.docker.com/r/kserve/modelmesh-runtime-adapter/tags)
    - [ ] [kserve/rest-proxy](https://hub.docker.com/r/kserve/rest-proxy/tags)
 
-3. In this `modelmesh-serving` repository, update the container image tags to
-   the corresponding release versions for:
+3. In this `modelmesh-serving` repository, on the `release-*` branch, update the
+   container image tags to the corresponding release versions for:
 
    - `kserve/modelmesh`
    - `kserve/modelmesh-controller`
@@ -109,6 +109,11 @@ with KServe.
 
    The version tags should be updated in the following files:
 
+   - [ ] `.github/workflows/fvt.yml`:
+     - [ ] `docker pull kserve/modelmesh:v...`
+     - [ ] `docker pull kserve/modelmesh-minio-dev-examples:v...`
+     - [ ] `docker pull kserve/modelmesh-runtime-adapter:v...`
+     - [ ] `docker pull kserve/rest-proxy:v...`
    - [ ] `config/default/config-defaults.yaml`:
      - [ ] `kserve/modelmesh`
      - [ ] `kserve/rest-proxy`
@@ -118,9 +123,11 @@ with KServe.
    - [ ] `config/manager/kustomization.yaml`: edit the `newTag`
    - [ ] `docs/component-versions.md`: update the version and component versions
    - [ ] `docs/install/install-script.md`: update the `RELEASE` variable in the
-         `Installation` section to the new `release-*` branch name
+         `Installation` section to the new `release-*` branch name and remove the
+         note pointing to the (old) `release-*` branch
    - [ ] `docs/quickstart.md`: update the `RELEASE` variable in the
-         _"Get the latest release"_ section to the new `release-*` branch name
+         _"Clone the ModelMesh repository"_ section to the new `release-*` branch
+         and remove the note of caution in the introduction above
    - [ ] `scripts/setup_user_namespaces.sh`: change the `modelmesh_release` version
 
    You can copy the checklist above into the PR description in the next step.
@@ -128,8 +135,10 @@ with KServe.
 4. Submit your PR to the `release-*` branch that was created earlier and wait for
    it to merge.
 
-5. Update the following files in the `main` branch with the same versions as in the
-   steps above, submit them in a PR to `main`, and wait for that PR to be merged:
+5. Update the following files in the `main` branch, replacing all occurrences
+   pointing to the old `release-*` branch or the previous release version tag
+   (e.g. `v0.11.0`) with the new release branch name or new version tags.
+   Submit them in a PR to `main`, and wait for that PR to be merged:
 
    - [ ] `docs/component-versions.md`
    - [ ] `docs/quickstart.md`
@@ -176,12 +185,12 @@ with KServe.
    ```
 
 4. Create the new release in the GitHub UI from the `release-*` branch (or from the
-   tag created in the previous step). Enter the release tag value (e.g. `v0.10.0`) in
+   tag created in the previous step). Enter the release tag value (e.g. `v0.11.0`) in
    the "Release title" field and upload the generated installation manifests ("Release assets")
    in the "Attach binaries ..." section. Click the "Generate release notes" button which
    will generate the release description.
 
-   **Note**, if you generated a pre-release (e.g. `v0.10.0-rc0`) then copy the release
+   **Note**, if you generated a pre-release (e.g. `v0.11.0-rc0`) then copy the release
    notes from that and remove them from the pre-release description and revise accordingly.
 
    https://github.com/kserve/modelmesh-serving/releases/new

--- a/fvt/README.md
+++ b/fvt/README.md
@@ -14,9 +14,9 @@ Functional Verification Test (FVT) suite for ModelMesh Serving using [Ginkgo](ht
 
 - CLIs:
   - [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
-  - [kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/) (v3.2.0+)
+  - [kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/) (v4.0.0+)
 - A Kubernetes or OpenShift cluster:
-  - Kubernetes version 1.16+
+  - Kubernetes version 1.23+
   - Cluster-administrative privileges
   - 12 vCPUs (3-nodes a 4 vCPU, or, 2-nodes a 8 vCPU)
   - 16 GB memory
@@ -25,7 +25,7 @@ For more details on cluster sizing, please see [here](/docs/install/README.md#de
 
 ### Install ModelMesh Serving
 
-The FVTs rely on a set of models existing in a configured `localMinIO` storage. The easiest way to get these models is to use a quick-start install with an instance of MinIO running the `kserve/modelmesh-minio-dev-examples` image.
+The FVTs rely on a set of models existing in a configured `localMinIO` storage. The easiest way to get these models is to use a quick-start installation with an instance of MinIO running the `kserve/modelmesh-minio-dev-examples` image.
 
 If starting with a fresh namespace, install ModelMesh Serving configured for the FVTs with:
 

--- a/scripts/setup_user_namespaces.sh
+++ b/scripts/setup_user_namespaces.sh
@@ -31,7 +31,7 @@ EOF
 
 ctrl_ns="modelmesh-serving"
 user_ns_array=()
-modelmesh_release="v0.10.0"       # The latest release is the default
+modelmesh_release="v0.11.0"       # The latest release is the default
 create_storage_secret=false
 deploy_serving_runtimes=false
 dev_mode=false                    # Set to true to use locally cloned files instead of from a release


### PR DESCRIPTION
#### Motivation

Several docs are still pointing to the previous release or are inconsistent in that the latest doc files from the `main` branch point to incompatible resources on the previous `release-0.10` branch or tagged release `v0.10.0`.

#### Modifications

- add tags when pre-pulling images for FVT (`latest`, `v...`)
- pre-pull minio-examples and minio-dev-examples images for FVT
  - one reason for the frequent timeouts in the FVT setup nodes
    - predictor tests using minio-dev-examples
    - storage tests for PVC using minio-examples (non -dev-)
- update links to `modelmesh` environment variables
- update install-script and quickstart to clone `main` branch, adding note pointing to the most recent stable release, and re-including the self-signed cert flag (#364)
- update required minimum Kubernetes version to `1.23` (HPA `autoscaling/v2`)
- update modelmesh component-versions to `v0.11.0`
- update release-process docs with additional places where versions need to be replaced


#### Result

Hopefully more consistent user experience when installing ModelMesh and more clarity for developers doing the release process.

FYI @rafvasq 

Related #408


