### PR TITLE
chore: Rename webhook (HPA)

### DIFF
--- a/config/default/webhookcainjection_patch.yaml
+++ b/config/default/webhookcainjection_patch.yaml
@@ -16,6 +16,6 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: servingruntime.serving.kserve.io
+  name: modelmesh-servingruntime.serving.kserve.io
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE_PLACEHOLDER)/$(CERTIFICATE_NAME_PLACEHOLDER)

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -14,7 +14,7 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: servingruntime.serving.kserve.io
+  name: modelmesh-servingruntime.serving.kserve.io
 webhooks:
   - admissionReviewVersions:
       - v1

--- a/scripts/self-signed-ca.sh
+++ b/scripts/self-signed-ca.sh
@@ -32,7 +32,7 @@ The following flags are optional.
        --service           Service name of webhook. Default: modelmesh-webhook-server-service
        --namespace         Namespace where webhook service and secret reside. Default: model-serving
        --secret            Secret name for CA certificate and server certificate/key pair. Default: modelmesh-webhook-server-cert
-       --webhookName       Name for the mutating and validating webhook config. Default: servingruntime.serving.kserve.io
+       --webhookName       Name for the mutating and validating webhook config. Default: modelmesh-servingruntime.serving.kserve.io
        --webhookDeployment deployment name of the webhook controller. Default: modelmesh-controller
 EOF
     exit 1
@@ -70,7 +70,7 @@ done
 [ -z ${secret} ] && secret=modelmesh-webhook-server-cert
 [ -z ${namespace} ] && namespace=model-serving
 [ -z ${webhookDeployment} ] && webhookDeployment=modelmesh-controller
-[ -z ${webhookName} ] && webhookName=servingruntime.serving.kserve.io
+[ -z ${webhookName} ] && webhookName=modelmesh-servingruntime.serving.kserve.io
 [ -z ${service} ] && service=modelmesh-webhook-server-service
 webhookDeploymentName=${webhookDeployment}
 webhookConfigName=${webhookName}


### PR DESCRIPTION
#### Motivation

We need to rename the `servingruntime.serving.kserve.io` validating webhook in ModelMesh to resolve a naming conflict in `kserve/kserve`:

https://github.com/kserve/kserve/actions/runs/5741094894/job/15561730774#step:10:209

```
helm install kserve charts/kserve-resources/ --wait --timeout 180s

...

Error: INSTALLATION FAILED: 1 error occurred:
	* validatingwebhookconfigurations.admissionregistration.k8s.io "servingruntime.serving.kserve.io" already exists


make: *** [Makefile:128: deploy-helm] Error 1
Error: Process completed with exit code 2.
```

https://github.com/kserve/kserve/pull/3031#discussion_r1284696404_
            

#### Modifications

Rename the `servingruntime.serving.kserve.io` to `modelmesh-servingruntime.serving.kserve.io`.

#### Result

TBD

#### Related

- [ ] kserve/kserve#3063
- [ ] kserve/kserve#3031
- [ ] kserve/kserve#3061

FYI @sivanantha321 @Jooho 
