### PR TITLE
chore: use generic Set instead of deprecated sets.String 

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -243,11 +243,6 @@ issues:
         - staticcheck
       text: "SA9003:"
 
-    # Exclude some deprecation errors
-    - linters:
-        - staticcheck
-      text: "SA1019:"
-
     # Exclude lll issues for long lines with go:generate
     - linters:
         - lll

--- a/controllers/modelmesh/constraints.go
+++ b/controllers/modelmesh/constraints.go
@@ -18,6 +18,8 @@ import (
 	"errors"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	kserveapi "github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -68,5 +70,5 @@ func (m *Deployment) addModelTypeConstraints(deployment *appsv1.Deployment) erro
 }
 
 func generateLabelsEnvVar(rts *kserveapi.ServingRuntimeSpec, restProxyEnabled bool, rtName string) string {
-	return strings.Join(GetServingRuntimeLabelSet(rts, restProxyEnabled, rtName).List(), ",")
+	return strings.Join(sets.List(GetServingRuntimeLabelSet(rts, restProxyEnabled, rtName)), ",")
 }

--- a/controllers/modelmesh/model_type_labels.go
+++ b/controllers/modelmesh/model_type_labels.go
@@ -24,10 +24,10 @@ import (
 )
 
 func GetServingRuntimeLabelSets(rt *kserveapi.ServingRuntimeSpec, restProxyEnabled bool, rtName string) (
-	mtLabels sets.String, pvLabels sets.String, rtLabel string) {
+	mtLabels sets.Set[string], pvLabels sets.Set[string], rtLabel string) {
 
 	// model type labels
-	mtSet := make(sets.String, 2*len(rt.SupportedModelFormats))
+	mtSet := make(sets.Set[string], 2*len(rt.SupportedModelFormats))
 	for _, t := range rt.SupportedModelFormats {
 		// only include model type labels when autoSelect is true
 		if t.AutoSelect != nil && *t.AutoSelect {
@@ -38,7 +38,7 @@ func GetServingRuntimeLabelSets(rt *kserveapi.ServingRuntimeSpec, restProxyEnabl
 		}
 	}
 	// protocol versions
-	pvSet := make(sets.String, len(rt.ProtocolVersions))
+	pvSet := make(sets.Set[string], len(rt.ProtocolVersions))
 	for _, pv := range rt.ProtocolVersions {
 		pvSet.Insert(fmt.Sprintf("pv:%s", pv))
 		if restProxyEnabled && pv == constants.ProtocolGRPCV2 {
@@ -49,7 +49,7 @@ func GetServingRuntimeLabelSets(rt *kserveapi.ServingRuntimeSpec, restProxyEnabl
 	return mtSet, pvSet, fmt.Sprintf("rt:%s", rtName)
 }
 
-func GetServingRuntimeLabelSet(rt *kserveapi.ServingRuntimeSpec, restProxyEnabled bool, rtName string) sets.String {
+func GetServingRuntimeLabelSet(rt *kserveapi.ServingRuntimeSpec, restProxyEnabled bool, rtName string) sets.Set[string] {
 	s1, s2, l := GetServingRuntimeLabelSets(rt, restProxyEnabled, rtName)
 	s1 = s1.Union(s2)
 	s1.Insert(l)

--- a/controllers/modelmesh/model_type_labels_test.go
+++ b/controllers/modelmesh/model_type_labels_test.go
@@ -19,6 +19,8 @@ import (
 	"sort"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	kserveapi "github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	"github.com/kserve/kserve/pkg/constants"
 	api "github.com/kserve/modelmesh-serving/apis/serving/v1alpha1"
@@ -82,11 +84,11 @@ func TestGetServingRuntimeLabelSets(t *testing.T) {
 	if expectedRtLabel != rtLabel {
 		t.Errorf("Missing expected entry [%s] in set: %v", expectedRtLabel, rtLabel)
 	}
-	if !reflect.DeepEqual(mtLabelSet.List(), expectedMtLabels) {
-		t.Errorf("Labels [%s] don't match expected: %v", mtLabelSet.List(), expectedMtLabels)
+	if !reflect.DeepEqual(sets.List(mtLabelSet), expectedMtLabels) {
+		t.Errorf("Labels [%s] don't match expected: %v", sets.List(mtLabelSet), expectedMtLabels)
 	}
-	if !reflect.DeepEqual(pvLabelSet.List(), expectedPvLabels) {
-		t.Errorf("Labels [%s] don't match expected: %v", pvLabelSet.List(), expectedPvLabels)
+	if !reflect.DeepEqual(sets.List(pvLabelSet), expectedPvLabels) {
+		t.Errorf("Labels [%s] don't match expected: %v", sets.List(pvLabelSet), expectedPvLabels)
 	}
 }
 

--- a/controllers/servingruntime_validator.go
+++ b/controllers/servingruntime_validator.go
@@ -140,7 +140,7 @@ func validateVolumes(rts *kserveapi.ServingRuntimeSpec, _ *config.Config) error 
 	return nil
 }
 
-func checkName(name string, internalNames sets.String, logStr string) error {
+func checkName(name string, internalNames sets.Set[string], logStr string) error {
 	if internalNames.Has(name) {
 		return fmt.Errorf("%s %s is reserved for internal use", logStr, name)
 	}
@@ -151,29 +151,29 @@ func checkName(name string, internalNames sets.String, logStr string) error {
 	return nil
 }
 
-var internalContainerNames = sets.NewString(
+var internalContainerNames = sets.New(
 	modelmesh.ModelMeshContainerName,
 	modelmesh.RESTProxyContainerName,
 	modelmesh.PullerContainerName,
 )
 
-var internalOnlyVolumeMounts = sets.NewString(
+var internalOnlyVolumeMounts = sets.New(
 	modelmesh.ConfigStorageMount,
 	modelmesh.EtcdVolume,
 	modelmesh.InternalConfigMapName,
 	modelmesh.SocketVolume,
 )
 
-var internalNamedPorts = sets.NewString("grpc", "http", "prometheus")
+var internalNamedPorts = sets.New[string]("grpc", "http", "prometheus")
 
-var internalPorts = sets.NewInt32(
+var internalPorts = sets.New[int32](
 	8080, // is used for LiteLinks communication in Model Mesh
 	8085, // is the port the built-in adapter listens on
 	8089, // is used for Model Mesh probes
 	8090, // is used for default preStop hooks
 )
 
-var internalVolumes = sets.NewString(
+var internalVolumes = sets.New[string](
 	modelmesh.ConfigStorageMount,
 	modelmesh.EtcdVolume,
 	modelmesh.InternalConfigMapName,

--- a/controllers/servingruntime_validator.go
+++ b/controllers/servingruntime_validator.go
@@ -151,13 +151,13 @@ func checkName(name string, internalNames sets.Set[string], logStr string) error
 	return nil
 }
 
-var internalContainerNames = sets.New(
+var internalContainerNames = sets.New[string](
 	modelmesh.ModelMeshContainerName,
 	modelmesh.RESTProxyContainerName,
 	modelmesh.PullerContainerName,
 )
 
-var internalOnlyVolumeMounts = sets.New(
+var internalOnlyVolumeMounts = sets.New[string](
 	modelmesh.ConfigStorageMount,
 	modelmesh.EtcdVolume,
 	modelmesh.InternalConfigMapName,


### PR DESCRIPTION
#### Motivation
To address deprecation warnings which appeared after updating to Go 1.19 in #379

#### Modifications
Updated deprecated code following [`sets` package doc](https://pkg.go.dev/k8s.io/apimachinery/pkg/util/sets#String), e.g.:
> `use generic Set instead. new ways: s1 := Set[string]{} s2 := New[string] ()`

#### Result
Resolves #386 