### PR TITLE
Support development version of Kustomize in install script

### DIFF
--- a/scripts/delete.sh
+++ b/scripts/delete.sh
@@ -95,13 +95,7 @@ popd
 
 # Older versions of kustomize have different load restrictor flag formats.
 # Can be removed once Kubeflow installation stops requiring v3.2.
-kustomize_version=$(kustomize version --short | grep -o -E "[0-9]\.[0-9]\.[0-9]")
-kustomize_load_restrictor_arg="--load-restrictor LoadRestrictionsNone"
-if [[ -n "$kustomize_version" && "$kustomize_version" < "3.4.0" ]]; then
-    kustomize_load_restrictor_arg="--load_restrictor none"
-elif [[ -n "$kustomize_version" && "$kustomize_version" < "4.0.1" ]]; then
-    kustomize_load_restrictor_arg="--load_restrictor LoadRestrictionsNone"
-fi
+kustomize_load_restrictor_arg=$( kustomize build --help | grep -o -E "\-\-load.restrictor[^,]+" | sed -E "s/(--load.restrictor).+'(.*none)'/\1 \2/I" )
 
 if [[ ! -z $user_ns_array ]]; then
   kustomize build runtimes ${kustomize_load_restrictor_arg} > runtimes.yaml

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -378,13 +378,7 @@ wait_for_pods_ready "-l control-plane=modelmesh-controller"
 
 # Older versions of kustomize have different load restrictor flag formats.
 # Can be removed once Kubeflow installation stops requiring v3.2.
-kustomize_version=$(kustomize version --short | grep -o -E "[0-9]\.[0-9]\.[0-9]")
-kustomize_load_restrictor_arg="--load-restrictor LoadRestrictionsNone"
-if [[ -n "$kustomize_version" && "$kustomize_version" < "3.4.0" ]]; then
-    kustomize_load_restrictor_arg="--load_restrictor none"
-elif [[ -n "$kustomize_version" && "$kustomize_version" < "4.0.1" ]]; then
-    kustomize_load_restrictor_arg="--load_restrictor LoadRestrictionsNone"
-fi
+kustomize_load_restrictor_arg=$( kustomize build --help | grep -o -E "\-\-load.restrictor[^,]+" | sed -E "s/(--load.restrictor).+'(.*none)'/\1 \2/I" )
 
 info "Installing ModelMesh Serving built-in runtimes"
 if [[ $namespace_scope_mode == "true" ]]; then

--- a/scripts/setup_user_namespaces.sh
+++ b/scripts/setup_user_namespaces.sh
@@ -72,13 +72,7 @@ if [[ ! -z $user_ns_array ]]; then
 
     # Older versions of kustomize have different load restrictor flag formats.
     # Can be removed once Kubeflow installation stops requiring v3.2.
-    kustomize_version=$(kustomize version --short | grep -o -E "[0-9]\.[0-9]\.[0-9]")
-    kustomize_load_restrictor_arg="--load-restrictor LoadRestrictionsNone"
-    if [[ -n "$kustomize_version" && "$kustomize_version" < "3.4.0" ]]; then
-        kustomize_load_restrictor_arg="--load_restrictor none"
-    elif [[ -n "$kustomize_version" && "$kustomize_version" < "4.0.1" ]]; then
-        kustomize_load_restrictor_arg="--load_restrictor LoadRestrictionsNone"
-    fi
+    kustomize_load_restrictor_arg=$( kustomize build --help | grep -o -E "\-\-load.restrictor[^,]+" | sed -E "s/(--load.restrictor).+'(.*none)'/\1 \2/I" )
 
     cp config/dependencies/minio-storage-secret.yaml .
     kustomize build config/runtimes ${kustomize_load_restrictor_arg} > runtimes.yaml


### PR DESCRIPTION
Closes #427 

#### Motivation

Kustomize version `(devel)` is not supported by the install script.

#### Modifications

Changed the regex so `(devel)` is a supported version.

#### Result

Install script now works when Kustomize is installed from https://kubectl.docs.kubernetes.io/installation/kustomize/source/
