### PR TITLE
release: Update image tags for v0.11.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-      - 'release-[0-9].[0-9]+*'
+      - 'release-[0-9][.0-9]+'
     tags:
       - 'v*'
     paths-ignore:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-      - 'release-[0-9].[0-9]+'
+      - 'release-[0-9].[0-9]+*'
     tags:
       - 'v*'
     paths-ignore:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-      - 'release-[0-9][.0-9]+'
+      - 'release-0.11.1'
     tags:
       - 'v*'
     paths-ignore:

--- a/.github/workflows/fvt.yml
+++ b/.github/workflows/fvt.yml
@@ -113,11 +113,11 @@ jobs:
           docker pull seldonio/mlserver:1.3.2
           docker pull openvino/model_server:2022.2
           # docker pull pytorch/torchserve:0.7.1-cpu
-          docker pull kserve/modelmesh:latest
-          docker pull kserve/modelmesh-minio-dev-examples:latest
-          docker pull kserve/modelmesh-minio-examples:latest
-          docker pull kserve/modelmesh-runtime-adapter:latest
-          docker pull kserve/rest-proxy:latest
+          docker pull kserve/modelmesh:v0.11.1
+          docker pull kserve/modelmesh-minio-dev-examples:v0.11.1
+          docker pull kserve/modelmesh-minio-examples:v0.11.1
+          docker pull kserve/modelmesh-runtime-adapter:v0.11.1
+          docker pull kserve/rest-proxy:v0.11.1
 
       - name: Check installation
         run: |

--- a/.github/workflows/fvt.yml
+++ b/.github/workflows/fvt.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches:
       - main
-      - 'release-[0-9].[0-9]+'
+      - 'release-[0-9].[0-9]+*'
     paths:
       - '**'
       - '!.github/**'

--- a/.github/workflows/fvt.yml
+++ b/.github/workflows/fvt.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches:
       - main
-      - 'release-[0-9][.0-9]+'
+      - 'release-0.11.1'
     paths:
       - '**'
       - '!.github/**'

--- a/.github/workflows/fvt.yml
+++ b/.github/workflows/fvt.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches:
       - main
-      - 'release-[0-9].[0-9]+*'
+      - 'release-[0-9][.0-9]+'
     paths:
       - '**'
       - '!.github/**'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-      - 'release-[0-9].[0-9]+*'
+      - 'release-[0-9][.0-9]+'
     paths-ignore:
       - '.github/**'
       - '.tekton/**'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-      - 'release-[0-9].[0-9]+'
+      - 'release-[0-9].[0-9]+*'
     paths-ignore:
       - '.github/**'
       - '.tekton/**'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-      - 'release-[0-9][.0-9]+'
+      - 'release-0.11.1'
     paths-ignore:
       - '.github/**'
       - '.tekton/**'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-      - 'release-[0-9].[0-9]+*'
+      - 'release-[0-9][.0-9]+'
     paths-ignore:
       - '.github/**'
       - '.tekton/**'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-      - 'release-[0-9].[0-9]+'
+      - 'release-[0-9].[0-9]+*'
     paths-ignore:
       - '.github/**'
       - '.tekton/**'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-      - 'release-[0-9][.0-9]+'
+      - 'release-0.11.1'
     paths-ignore:
       - '.github/**'
       - '.tekton/**'

--- a/config/default/config-defaults.yaml
+++ b/config/default/config-defaults.yaml
@@ -16,7 +16,7 @@ podsPerRuntime: 2
 headlessService: true
 modelMeshImage:
   name: kserve/modelmesh
-  tag: latest
+  tag: v0.11.1
 modelMeshResources:
   requests:
     cpu: "300m"
@@ -29,7 +29,7 @@ restProxy:
   port: 8008
   image:
     name: kserve/rest-proxy
-    tag: latest
+    tag: v0.11.1
   resources:
     requests:
       cpu: "50m"
@@ -39,7 +39,7 @@ restProxy:
       memory: "512Mi"
 storageHelperImage:
   name: kserve/modelmesh-runtime-adapter
-  tag: latest
+  tag: v0.11.1
   command: ["/opt/app/puller"]
 storageHelperResources:
   requests:

--- a/config/dependencies/quickstart.yaml
+++ b/config/dependencies/quickstart.yaml
@@ -110,7 +110,7 @@ spec:
             - name: MINIO_SECRET_KEY
               value: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
           # image: quay.io/cloudservices/minio:latest
-          image: kserve/modelmesh-minio-examples:latest
+          image: kserve/modelmesh-minio-examples:v0.11.1
           name: minio
 ---
 apiVersion: v1

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -18,4 +18,4 @@ images:
   - name: modelmesh-controller
     newName: kserve/modelmesh-controller
     ## NOTE THIS SHOULD BE REPLACED WITH LATEST CONTROLLER IMAGE TAG
-    newTag: latest
+    newTag: v0.11.1

--- a/controllers/modelmesh/modelmesh.go
+++ b/controllers/modelmesh/modelmesh.go
@@ -261,24 +261,24 @@ func (m *Deployment) addMMEnvVars(deployment *appsv1.Deployment) error {
 	}
 
 	if m.EnableAccessLogging {
-		// See https://github.com/kserve/modelmesh/blob/v0.11.0/src/main/java/com/ibm/watson/modelmesh/ModelMeshEnvVars.java#L55
+		// See https://github.com/kserve/modelmesh/blob/v0.11.1/src/main/java/com/ibm/watson/modelmesh/ModelMeshEnvVars.java#L55
 		if err := setEnvironmentVar(ModelMeshContainerName, "MM_LOG_EACH_INVOKE", "true", deployment); err != nil {
 			return err
 		}
 	}
 
 	if m.GrpcMaxMessageSize > 0 {
-		// See https://github.com/kserve/modelmesh/blob/v0.11.0/src/main/java/com/ibm/watson/modelmesh/ModelMeshEnvVars.java#L38
+		// See https://github.com/kserve/modelmesh/blob/v0.11.1/src/main/java/com/ibm/watson/modelmesh/ModelMeshEnvVars.java#L38
 		if err := setEnvironmentVar(ModelMeshContainerName, "MM_SVC_GRPC_MAX_MSG_SIZE", strconv.Itoa(m.GrpcMaxMessageSize), deployment); err != nil {
 			return err
 		}
 	}
 
-	// See https://github.com/kserve/modelmesh/blob/v0.11.0/src/main/java/com/ibm/watson/modelmesh/ModelMeshEnvVars.java#L31
+	// See https://github.com/kserve/modelmesh/blob/v0.11.1/src/main/java/com/ibm/watson/modelmesh/ModelMeshEnvVars.java#L31
 	if err := setEnvironmentVar(ModelMeshContainerName, "MM_KVSTORE_PREFIX", ModelMeshEtcdPrefix, deployment); err != nil {
 		return err
 	}
-	// See https://github.com/kserve/modelmesh/blob/v0.11.0/src/main/java/com/ibm/watson/modelmesh/ModelMeshEnvVars.java#L68
+	// See https://github.com/kserve/modelmesh/blob/v0.11.1/src/main/java/com/ibm/watson/modelmesh/ModelMeshEnvVars.java#L68
 	if err := setEnvironmentVar(ModelMeshContainerName, "MM_DEFAULT_VMODEL_OWNER", m.DefaultVModelOwner, deployment); err != nil {
 		return err
 	}

--- a/docs/component-versions.md
+++ b/docs/component-versions.md
@@ -3,6 +3,6 @@
 The following table shows the component versions for the latest modelmesh-serving release (v0.11.1).
 | Component | Description | Upstream Revision |
 | - | - | - |
-| ModelMesh | Serves as a general-purpose model serving management/routing layer | [v0.11.1](https://github.com/kserve/modelmesh/tree/v0.11.0) |
+| ModelMesh | Serves as a general-purpose model serving management/routing layer | [v0.11.1](https://github.com/kserve/modelmesh/tree/v0.11.1) |
 | ModelMesh Runtime Adapter | Contains the unified puller/runtime-adapter image | [v0.11.1](https://github.com/kserve/modelmesh-runtime-adapter/tree/v0.11.1) |
 | REST Proxy | Supports inference requests using KServe V2 REST Predict Protocol | [v0.11.1](https://github.com/kserve/rest-proxy/tree/v0.11.1) |

--- a/docs/component-versions.md
+++ b/docs/component-versions.md
@@ -1,8 +1,8 @@
 # Component versions
 
-The following table shows the component versions for the latest modelmesh-serving release (v0.11.0).
+The following table shows the component versions for the latest modelmesh-serving release (v0.11.1).
 | Component | Description | Upstream Revision |
 | - | - | - |
-| ModelMesh | Serves as a general-purpose model serving management/routing layer | [v0.11.0](https://github.com/kserve/modelmesh/tree/v0.11.0) |
-| ModelMesh Runtime Adapter | Contains the unified puller/runtime-adapter image | [v0.11.0](https://github.com/kserve/modelmesh-runtime-adapter/tree/v0.11.0) |
-| REST Proxy | Supports inference requests using KServe V2 REST Predict Protocol | [v0.11.0](https://github.com/kserve/rest-proxy/tree/v0.11.0) |
+| ModelMesh | Serves as a general-purpose model serving management/routing layer | [v0.11.1](https://github.com/kserve/modelmesh/tree/v0.11.0) |
+| ModelMesh Runtime Adapter | Contains the unified puller/runtime-adapter image | [v0.11.1](https://github.com/kserve/modelmesh-runtime-adapter/tree/v0.11.1) |
+| REST Proxy | Supports inference requests using KServe V2 REST Predict Protocol | [v0.11.1](https://github.com/kserve/rest-proxy/tree/v0.11.1) |

--- a/docs/install/install-script.md
+++ b/docs/install/install-script.md
@@ -42,15 +42,15 @@ A secret named `model-serving-etcd` will be created and passed to the controller
 
 <!-- Remove the following note on the `release-*` branch -->
 
-To install the most recent _stable release_ of [modelmesh-serving](https://github.com/kserve/modelmesh-serving/releases/latest)
-follow the [Installation instructions](https://github.com/kserve/modelmesh-serving/blob/release-0.11/docs/install/install-script.md) for version `v0.11.0`.
+To install the most recent _stable release_ of [modelmesh-serving](https://github.com/kserve/modelmesh-serving/releases/v0.11.1)
+follow the [Installation instructions](https://github.com/kserve/modelmesh-serving/blob/release-0.11.1/docs/install/install-script.md) for version `v0.11.1`.
 
 Start by cloning the [modelmesh-serving](https://github.com/kserve/modelmesh-serving.git) repository:
 
-<!-- Replace with RELEASE="release-0.11" on the `release-*` branch -->
+<!-- Replace with RELEASE="release-0.11.1" on the `release-*` branch -->
 
 ```shell
-RELEASE="main"
+RELEASE="release-0.11.1"
 git clone -b $RELEASE --depth 1 --single-branch https://github.com/kserve/modelmesh-serving.git
 cd modelmesh-serving
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,7 +4,7 @@ To quickly get started using ModelMesh Serving, here is a brief guide.
 
 <!-- Remove the following note on the `release-*` branch -->
 
-> **Note**: This document describes how to install the _latest unreleased_ version of ModelMesh for developers and early adopters. To install the most recent _stable release_, please follow the [Quick Start Guide for version 0.11](https://github.com/kserve/modelmesh-serving/blob/release-0.11/docs/quickstart.md).
+> **Note**: This document describes how to install the _latest unreleased_ version of ModelMesh for developers and early adopters. To install the most recent _stable release_, please follow the [Quick Start Guide for version 0.11.1](https://github.com/kserve/modelmesh-serving/blob/release-0.11.1/docs/quickstart.md).
 
 ## Prerequisites
 
@@ -16,10 +16,10 @@ To quickly get started using ModelMesh Serving, here is a brief guide.
 
 ### Clone the ModelMesh repository
 
-<!-- Replace with RELEASE="release-0.11" on the `release-*` branch -->
+<!-- Replace with RELEASE="release-0.11.1" on the `release-*` branch -->
 
 ```shell
-RELEASE="main"
+RELEASE="release-0.11.1"
 git clone -b $RELEASE --depth 1 --single-branch https://github.com/kserve/modelmesh-serving.git
 cd modelmesh-serving
 ```

--- a/scripts/setup_user_namespaces.sh
+++ b/scripts/setup_user_namespaces.sh
@@ -31,7 +31,7 @@ EOF
 
 ctrl_ns="modelmesh-serving"
 user_ns_array=()
-modelmesh_release="v0.11.0"       # The latest release is the default
+modelmesh_release="release-0.11.1"       # The latest release is the default
 create_storage_secret=false
 deploy_serving_runtimes=false
 dev_mode=false                    # Set to true to use locally cloned files instead of from a release

--- a/scripts/setup_user_namespaces.sh
+++ b/scripts/setup_user_namespaces.sh
@@ -31,7 +31,7 @@ EOF
 
 ctrl_ns="modelmesh-serving"
 user_ns_array=()
-modelmesh_release="release-0.11.1"       # The latest release is the default
+modelmesh_release="v0.11.1"       # The latest release is the default
 create_storage_secret=false
 deploy_serving_runtimes=false
 dev_mode=false                    # Set to true to use locally cloned files instead of from a release


### PR DESCRIPTION
#### Release checklist

**Create release tags (`v0.11.1`) in these repositories:**
 - [x] [`modelmesh`](https://github.com/kserve/modelmesh/releases)
 - [x] [`modelmesh-minio-examples`](https://github.com/kserve/modelmesh-minio-examples/releases)
 - [x] [`modelmesh-runtime-adapter`](https://github.com/kserve/modelmesh-runtime-adapter/releases)
 - [x] [`rest-proxy`](https://github.com/kserve/rest-proxy/releases)

**Verify image tags got pushed to [DockerHub](https://hub.docker.com/u/kserve):**
 - [x] [kserve/modelmesh](https://hub.docker.com/r/kserve/modelmesh/tags)
 - [x] [kserve/modelmesh-minio-examples](https://hub.docker.com/r/kserve/modelmesh-minio-examples/tags)
 - [x] [kserve/modelmesh-runtime-adapter](https://hub.docker.com/r/kserve/modelmesh-runtime-adapter/tags)
 - [x] [kserve/rest-proxy](https://hub.docker.com/r/kserve/rest-proxy/tags)

**Update versions in the following files:**
 - [x] `config/default/config-defaults.yaml`: edit the images tags for ...
     - [x] `kserve/modelmesh`
     - [x] `kserve/rest-proxy`
     - [x] `kserve/modelmesh-runtime-adapter` 
 - [x] `config/dependencies/quickstart.yaml`: change the `kserve/modelmesh-minio-examples` image tag to use the pinned version
 - [x] `config/manager/kustomization.yaml`: edit the `newTag`
 - [x] `docs/component-versions.md`: update the version and component versions
 - [x] `docs/install/install-script.md`: update the `RELEASE` variable in the `Installation` section to the new `release-*` branch name
 - [x] `docs/quickstart.md`: update the `RELEASE` variable in the _"Get the latest release"_ section to the new `release-*` branch name
 - [x] `scripts/setup_user_namespaces.sh`: change the `modelmesh_release` version