### PR TITLE
test: Add FVT in namespace-scope mode

### DIFF
--- a/.github/workflows/fvt-base.yml
+++ b/.github/workflows/fvt-base.yml
@@ -119,9 +119,10 @@ jobs:
         run: |
           eval $(minikube -p minikube docker-env)
           docker images
+          kubectl get svc
           kubectl get pods
-          kubectl get clusterservingruntimes
-          kubectl get servingruntimes
+          kubectl get clusterservingruntimes 2> /dev/null || :
+          kubectl get servingruntimes 2> /dev/null || :
 
       - name: Run FVTs
         run: |

--- a/.github/workflows/fvt-base.yml
+++ b/.github/workflows/fvt-base.yml
@@ -90,7 +90,6 @@ jobs:
           ./scripts/build_docker.sh --target runtime --tag ${{ env.IMAGE_TAG }}
 
       - name: Install ModelMesh Serving
-        if: ${{ inputs.perform_deploy }}
         run: |
           export NAMESPACE_SCOPE_MODE=${{ inputs.namespace-scope-mode }}
           kubectl create ns modelmesh-serving
@@ -122,6 +121,7 @@ jobs:
           docker images
           kubectl get pods
           kubectl get clusterservingruntimes
+          kubectl get servingruntimes
 
       - name: Run FVTs
         run: |

--- a/.github/workflows/fvt-base.yml
+++ b/.github/workflows/fvt-base.yml
@@ -1,18 +1,13 @@
-name: FVT
+name: FVT Base
 
 on:
-  workflow_dispatch:
-  pull_request:
-    branches:
-      - main
-      - 'release-[0-9].[0-9]+'
-    paths:
-      - '**'
-      - '!.github/**'
-      - '!.tekton/**'
-      - '!**.md'
-      - '!docs/**'
-      - '.github/workflows/fvt.yml'
+  workflow_call:
+    inputs:
+      namespace-scope-mode:
+        description: 'Whether to deploy ModelMesh Serving in namespace-scope mode'
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   fvt:
@@ -95,7 +90,9 @@ jobs:
           ./scripts/build_docker.sh --target runtime --tag ${{ env.IMAGE_TAG }}
 
       - name: Install ModelMesh Serving
+        if: ${{ inputs.perform_deploy }}
         run: |
+          export NAMESPACE_SCOPE_MODE=${{ inputs.namespace-scope-mode }}
           kubectl create ns modelmesh-serving
           ./scripts/install.sh --namespace modelmesh-serving --fvt --dev-mode-logging
 
@@ -131,5 +128,5 @@ jobs:
           go install github.com/onsi/ginkgo/v2/ginkgo
           export PATH=/root/go/bin/:$PATH
           export NAMESPACE=modelmesh-serving
-          export NAMESPACESCOPEMODE=false
+          export NAMESPACESCOPEMODE=${{ inputs.namespace-scope-mode }}
           make fvt

--- a/.github/workflows/fvt-cs.yml
+++ b/.github/workflows/fvt-cs.yml
@@ -15,7 +15,7 @@ on:
       - '.github/workflows/fvt*.yml'
 
 jobs:
-  fvt-namespace-scope:
+  fvt-cluster-scope:
     uses: ./.github/workflows/fvt-base.yml
     with:
       namespace-scope-mode: false

--- a/.github/workflows/fvt-cs.yml
+++ b/.github/workflows/fvt-cs.yml
@@ -1,0 +1,22 @@
+name: FVT Cluster Scope
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+      - 'release-[0-9].[0-9]+'
+    paths:
+      - '**'
+      - '!.github/**'
+      - '!.tekton/**'
+      - '!**.md'
+      - '!docs/**'
+      - '.github/workflows/fvt*.yml'
+
+jobs:
+  fvt-namespace-scope:
+    uses: ./.github/workflows/fvt-base.yml
+    with:
+      namespace-scope-mode: false
+    secrets: inherit

--- a/.github/workflows/fvt-ns.yml
+++ b/.github/workflows/fvt-ns.yml
@@ -1,0 +1,22 @@
+name: FVT Namespace Scope
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+      - 'release-[0-9].[0-9]+'
+    paths:
+      - '**'
+      - '!.github/**'
+      - '!.tekton/**'
+      - '!**.md'
+      - '!docs/**'
+      - '.github/workflows/fvt*.yml'
+
+jobs:
+  fvt-namespace-scope:
+    uses: ./.github/workflows/fvt-base.yml
+    with:
+      namespace-scope-mode: true
+    secrets: inherit

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -25,7 +25,7 @@ dev_mode_logging=false
 quickstart=false
 fvt=false
 user_ns_array=
-namespace_scope_mode=false # change to true to run in namespace scope
+namespace_scope_mode=${NAMESPACE_SCOPE_MODE:-false}
 modelmesh_serving_image=
 enable_self_signed_ca=false
 


### PR DESCRIPTION
#### Motivation

Our current FVT setup only tests ModelMesh Serving deployed in cluster-scope mode. Issue [#433](https://github.com/kserve/modelmesh-serving/issues/433#issuecomment-1738022152) revealed that this is insufficient as it missed a major regression that only surfaced when ModelMesh Serving was deployed in namespace-scope mode. The namespace-scope mode is used for the [Quickstart installation](https://github.com/kserve/modelmesh-serving/blob/main/docs/quickstart.md#run-the-installation-script) which makes any such regressions very visible.

```shell
./scripts/install.sh --namespace-scope-mode --namespace modelmesh-serving --quickstart ...
```
        
#### Modifications

- Transform the current FVT workflow into a [reusable workflow](https://docs.github.com/en/actions/using-workflows/reusing-workflows#overview): `fvt-base.yml` 
- Create 2 separate new workflows that call the FVT Base workflow with a `namespace-scope-mode` input parameter

The new workflows should run in parallel to not increase the overall time required for PR checks to be completed.

#### Result

Both FVT workflows for cluster-scope and namespace-scope mode run in parallel:

- https://github.com/kserve/modelmesh-serving/actions/runs/6490495439/job/17626354063#step:11:41
- https://github.com/kserve/modelmesh-serving/actions/runs/6490495443/job/17626354124#step:11:41

Resolves #436

