### PR TITLE
Replace "foo" string with a less generic one

### DIFF
--- a/controllers/config/templating.go
+++ b/controllers/config/templating.go
@@ -49,7 +49,7 @@ func templateSource(r io.Reader, context interface{}) mf.Source {
 	if err != nil {
 		panic(err)
 	}
-	t, err := template.New("foo").Parse(string(b))
+	t, err := template.New("ModelMeshTemplate").Parse(string(b))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
If template parsing fails, the "foo" string would appear in pod logs. This should be very hard to happen, since the template is built-in. Changing, simply, to have more meaningful logs.

Fixes opendatahub-io/modelmesh-serving#114