### PR TITLE
release: Update `v0.11.2` image tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-      - 'release-[0-9].[0-9]+'
+      - 'release-0.11.2'
     tags:
       - 'v*'
     paths-ignore:

--- a/.github/workflows/fvt-base.yml
+++ b/.github/workflows/fvt-base.yml
@@ -109,11 +109,11 @@ jobs:
           docker pull seldonio/mlserver:1.3.2
           docker pull openvino/model_server:2022.2
           # docker pull pytorch/torchserve:0.7.1-cpu
-          docker pull kserve/modelmesh:latest
-          docker pull kserve/modelmesh-minio-dev-examples:latest
-          docker pull kserve/modelmesh-minio-examples:latest
-          docker pull kserve/modelmesh-runtime-adapter:latest
-          docker pull kserve/rest-proxy:latest
+          docker pull kserve/modelmesh:v0.11.2
+          docker pull kserve/modelmesh-minio-dev-examples:v0.11.2
+          docker pull kserve/modelmesh-minio-examples:v0.11.2
+          docker pull kserve/modelmesh-runtime-adapter:v0.11.2
+          docker pull kserve/rest-proxy:v0.11.2
 
       - name: Check installation
         run: |

--- a/.github/workflows/fvt-cs.yml
+++ b/.github/workflows/fvt-cs.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches:
       - main
-      - 'release-[0-9].[0-9]+'
+      - 'release-0.11.2'
     paths:
       - '**'
       - '!.github/**'

--- a/.github/workflows/fvt-ns.yml
+++ b/.github/workflows/fvt-ns.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches:
       - main
-      - 'release-[0-9].[0-9]+'
+      - 'release-0.11.2'
     paths:
       - '**'
       - '!.github/**'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-      - 'release-[0-9].[0-9]+'
+      - 'release-0.11.2'
     paths-ignore:
       - '.github/**'
       - '.tekton/**'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-      - 'release-[0-9].[0-9]+'
+      - 'release-0.11.2'
     paths-ignore:
       - '.github/**'
       - '.tekton/**'

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ bin
 devbuild
 .develop_image_name
 .dev/
+.pre-commit.log

--- a/config/default/config-defaults.yaml
+++ b/config/default/config-defaults.yaml
@@ -16,7 +16,7 @@ podsPerRuntime: 2
 headlessService: true
 modelMeshImage:
   name: kserve/modelmesh
-  tag: latest
+  tag: v0.11.2
 modelMeshResources:
   requests:
     cpu: "300m"
@@ -29,7 +29,7 @@ restProxy:
   port: 8008
   image:
     name: kserve/rest-proxy
-    tag: latest
+    tag: v0.11.2
   resources:
     requests:
       cpu: "50m"
@@ -39,7 +39,7 @@ restProxy:
       memory: "512Mi"
 storageHelperImage:
   name: kserve/modelmesh-runtime-adapter
-  tag: latest
+  tag: v0.11.2
   command: ["/opt/app/puller"]
 storageHelperResources:
   requests:

--- a/config/dependencies/fvt.yaml
+++ b/config/dependencies/fvt.yaml
@@ -108,7 +108,7 @@ spec:
               value: AKIAIOSFODNN7EXAMPLE
             - name: MINIO_SECRET_KEY
               value: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-          image: kserve/modelmesh-minio-dev-examples:latest
+          image: kserve/modelmesh-minio-dev-examples:v0.11.2
           name: minio
 ---
 apiVersion: v1
@@ -171,7 +171,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: "copy-pod"
-          image: kserve/modelmesh-minio-examples:latest
+          image: kserve/modelmesh-minio-examples:v0.11.2
           securityContext:
             runAsUser: 0
             allowPrivilegeEscalation: false

--- a/config/dependencies/quickstart.yaml
+++ b/config/dependencies/quickstart.yaml
@@ -110,7 +110,7 @@ spec:
             - name: MINIO_SECRET_KEY
               value: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
           # image: quay.io/cloudservices/minio:latest
-          image: kserve/modelmesh-minio-examples:latest
+          image: kserve/modelmesh-minio-examples:v0.11.2
           name: minio
 ---
 apiVersion: v1

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -18,4 +18,4 @@ images:
   - name: modelmesh-controller
     newName: kserve/modelmesh-controller
     ## NOTE THIS SHOULD BE REPLACED WITH LATEST CONTROLLER IMAGE TAG
-    newTag: latest
+    newTag: v0.11.2

--- a/docs/component-versions.md
+++ b/docs/component-versions.md
@@ -2,8 +2,8 @@
 
 The following table shows the component versions for the latest ModelMesh Serving release (v0.11.2).
 
-| Component                  | Description                                                        | Upstream Revision                                                           |
-|----------------------------|--------------------------------------------------------------------|-----------------------------------------------------------------------------|
-| ModelMesh                  | Serves as a general-purpose model serving management/routing layer | [v0.11.2](https://github.com/kserve/modelmesh/tree/v0.11.2)                 |
-| ModelMesh Runtime Adapter  | Contains the unified puller/runtime-adapter image                  | [v0.11.2](https://github.com/kserve/modelmesh-runtime-adapter/tree/v0.11.2) |
-| REST Proxy                 | Supports inference requests using KServe V2 REST Predict Protocol  | [v0.11.2](https://github.com/kserve/rest-proxy/tree/v0.11.2)                |
+| Component                 | Description                                                        | Upstream Revision                                                           |
+| ------------------------- | ------------------------------------------------------------------ | --------------------------------------------------------------------------- |
+| ModelMesh                 | Serves as a general-purpose model serving management/routing layer | [v0.11.2](https://github.com/kserve/modelmesh/tree/v0.11.2)                 |
+| ModelMesh Runtime Adapter | Contains the unified puller/runtime-adapter image                  | [v0.11.2](https://github.com/kserve/modelmesh-runtime-adapter/tree/v0.11.2) |
+| REST Proxy                | Supports inference requests using KServe V2 REST Predict Protocol  | [v0.11.2](https://github.com/kserve/rest-proxy/tree/v0.11.2)                |

--- a/docs/component-versions.md
+++ b/docs/component-versions.md
@@ -1,8 +1,9 @@
 # Component versions
 
-The following table shows the component versions for the latest modelmesh-serving release (v0.11.0).
-| Component | Description | Upstream Revision |
-| - | - | - |
-| ModelMesh | Serves as a general-purpose model serving management/routing layer | [v0.11.0](https://github.com/kserve/modelmesh/tree/v0.11.0) |
-| ModelMesh Runtime Adapter | Contains the unified puller/runtime-adapter image | [v0.11.0](https://github.com/kserve/modelmesh-runtime-adapter/tree/v0.11.0) |
-| REST Proxy | Supports inference requests using KServe V2 REST Predict Protocol | [v0.11.0](https://github.com/kserve/rest-proxy/tree/v0.11.0) |
+The following table shows the component versions for the latest ModelMesh Serving release (v0.11.2).
+
+| Component                  | Description                                                        | Upstream Revision                                                           |
+|----------------------------|--------------------------------------------------------------------|-----------------------------------------------------------------------------|
+| ModelMesh                  | Serves as a general-purpose model serving management/routing layer | [v0.11.2](https://github.com/kserve/modelmesh/tree/v0.11.2)                 |
+| ModelMesh Runtime Adapter  | Contains the unified puller/runtime-adapter image                  | [v0.11.2](https://github.com/kserve/modelmesh-runtime-adapter/tree/v0.11.2) |
+| REST Proxy                 | Supports inference requests using KServe V2 REST Predict Protocol  | [v0.11.2](https://github.com/kserve/rest-proxy/tree/v0.11.2)                |

--- a/docs/install/install-script.md
+++ b/docs/install/install-script.md
@@ -43,14 +43,12 @@ A secret named `model-serving-etcd` will be created and passed to the controller
 <!-- Remove the following note on the `release-*` branch -->
 
 To install the most recent _stable release_ of [modelmesh-serving](https://github.com/kserve/modelmesh-serving/releases/latest)
-follow the [Installation instructions](https://github.com/kserve/modelmesh-serving/blob/release-0.11/docs/install/install-script.md) for version `v0.11.0`.
+follow the [Installation instructions](https://github.com/kserve/modelmesh-serving/blob/release-0.11.2/docs/install/install-script.md) for version `v0.11.2`.
 
 Start by cloning the [modelmesh-serving](https://github.com/kserve/modelmesh-serving.git) repository:
 
-<!-- Replace with RELEASE="release-0.11" on the `release-*` branch -->
-
 ```shell
-RELEASE="main"
+RELEASE="release-0.11.2"
 git clone -b $RELEASE --depth 1 --single-branch https://github.com/kserve/modelmesh-serving.git
 cd modelmesh-serving
 ```

--- a/docs/install/install-script.md
+++ b/docs/install/install-script.md
@@ -40,11 +40,6 @@ A secret named `model-serving-etcd` will be created and passed to the controller
 
 ## Installation
 
-<!-- Remove the following note on the `release-*` branch -->
-
-To install the most recent _stable release_ of [modelmesh-serving](https://github.com/kserve/modelmesh-serving/releases/latest)
-follow the [Installation instructions](https://github.com/kserve/modelmesh-serving/blob/release-0.11.2/docs/install/install-script.md) for version `v0.11.2`.
-
 Start by cloning the [modelmesh-serving](https://github.com/kserve/modelmesh-serving.git) repository:
 
 ```shell

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,10 +2,6 @@
 
 To quickly get started using ModelMesh Serving, here is a brief guide.
 
-<!-- Remove the following note on the `release-*` branch -->
-
-> **Note**: This document describes how to install the _latest unreleased_ version of ModelMesh for developers and early adopters. To install the most recent _stable release_, please follow the [Quick Start Guide for version 0.11.2](https://github.com/kserve/modelmesh-serving/blob/release-0.11.2/docs/quickstart.md).
-
 ## Prerequisites
 
 - A Kubernetes cluster v1.23+ with cluster administrative privileges

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,7 +4,7 @@ To quickly get started using ModelMesh Serving, here is a brief guide.
 
 <!-- Remove the following note on the `release-*` branch -->
 
-> **Note**: This document describes how to install the _latest unreleased_ version of ModelMesh for developers and early adopters. To install the most recent _stable release_, please follow the [Quick Start Guide for version 0.11](https://github.com/kserve/modelmesh-serving/blob/release-0.11/docs/quickstart.md).
+> **Note**: This document describes how to install the _latest unreleased_ version of ModelMesh for developers and early adopters. To install the most recent _stable release_, please follow the [Quick Start Guide for version 0.11.2](https://github.com/kserve/modelmesh-serving/blob/release-0.11.2/docs/quickstart.md).
 
 ## Prerequisites
 
@@ -16,10 +16,8 @@ To quickly get started using ModelMesh Serving, here is a brief guide.
 
 ### Clone the ModelMesh repository
 
-<!-- Replace with RELEASE="release-0.11" on the `release-*` branch -->
-
 ```shell
-RELEASE="main"
+RELEASE="release-0.11.2"
 git clone -b $RELEASE --depth 1 --single-branch https://github.com/kserve/modelmesh-serving.git
 cd modelmesh-serving
 ```

--- a/scripts/setup_user_namespaces.sh
+++ b/scripts/setup_user_namespaces.sh
@@ -31,7 +31,7 @@ EOF
 
 ctrl_ns="modelmesh-serving"
 user_ns_array=()
-modelmesh_release="v0.11.0"       # The latest release is the default
+modelmesh_release="v0.11.2"       # The latest release is the default
 create_storage_secret=false
 deploy_serving_runtimes=false
 dev_mode=false                    # Set to true to use locally cloned files instead of from a release


### PR DESCRIPTION
#### Motivation

Update image tags for `v0.11.2` following the [release process](https://github.com/kserve/modelmesh-serving/blob/main/docs/release-process.md#update-release-tags):

#### Modifications

1. Create new (pre-)release tags (`v0.11.2`) in these repositories:

   - [x] [`modelmesh`](https://github.com/kserve/modelmesh/releases)
   - [x] [`modelmesh-minio-examples`](https://github.com/kserve/modelmesh-minio-examples/releases)
   - [x] [`modelmesh-runtime-adapter`](https://github.com/kserve/modelmesh-runtime-adapter/releases)
   - [x] [`rest-proxy`](https://github.com/kserve/rest-proxy/releases)

2. Verify image tags were pushed to [DockerHub](https://hub.docker.com/u/kserve):

   - [x] [kserve/modelmesh](https://hub.docker.com/r/kserve/modelmesh/tags)
   - [x] [kserve/modelmesh-minio-examples](https://hub.docker.com/r/kserve/modelmesh-minio-examples/tags)
   - [x] [kserve/modelmesh-runtime-adapter](https://hub.docker.com/r/kserve/modelmesh-runtime-adapter/tags)
   - [x] [kserve/rest-proxy](https://hub.docker.com/r/kserve/rest-proxy/tags)

3. In this `modelmesh-serving` repository, on the `release-0.11.2` branch, update the
   container image tags to the corresponding release versions in the following files:

   - [x] `.github/workflows/fvt-base.yml`:
     - [x] `docker pull kserve/modelmesh:v...`
     - [x] `docker pull kserve/modelmesh-minio-examples:v...`
     - [x] `docker pull kserve/modelmesh-minio-dev-examples:v...`
     - [x] `docker pull kserve/modelmesh-runtime-adapter:v...`
     - [x] `docker pull kserve/rest-proxy:v...`
   - [x] `config/default/config-defaults.yaml`:
     - [x] `kserve/modelmesh`
     - [x] `kserve/rest-proxy`
     - [x] `kserve/modelmesh-runtime-adapter`
   - [x] `config/dependencies/fvt.yaml`:
      - [x] `image: kserve/modelmesh-minio-dev-examples:v...`
      - [x] `image: kserve/modelmesh-minio-examples:v...`
   - [x] `config/dependencies/quickstart.yaml`:
     - [x] `image: kserve/modelmesh-minio-examples:v...`
   - [x] `config/manager/kustomization.yaml`: update the `newTag` to `v...`
   - [x] `docs/component-versions.md`: update tags and repo links
     - [x] ModelMesh Serving release
     - [x] ModelMesh
     - [x] ModelMesh Runtime Adapter
     - [x] REST Proxy
   - [x] `docs/install/install-script.md`: update the `RELEASE` variable in the
         `Installation` section to the new `release-*` branch name and remove the
         note pointing to the (old) `release-*` branch
   - [x] `docs/quickstart.md`: update the `RELEASE` variable in the
         _"Clone the ModelMesh repository"_ section to the new `release-*` branch
         and remove the note of caution in the introduction above
   - [x] `scripts/setup_user_namespaces.sh`: change the `modelmesh_release` version


#### Result

4. [x] Submit your PR to the `release-*` branch that was created earlier and wait for
   it to merge.