### PR TITLE
docs: Updates post release v0.11.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,3 @@ devbuild
 .develop_image_name
 .dev/
 .pre-commit.log
-

--- a/docs/component-versions.md
+++ b/docs/component-versions.md
@@ -1,8 +1,9 @@
 # Component versions
 
-The following table shows the component versions for the latest modelmesh-serving release (v0.11.0).
-| Component | Description | Upstream Revision |
-| - | - | - |
-| ModelMesh | Serves as a general-purpose model serving management/routing layer | [v0.11.0](https://github.com/kserve/modelmesh/tree/v0.11.0) |
-| ModelMesh Runtime Adapter | Contains the unified puller/runtime-adapter image | [v0.11.0](https://github.com/kserve/modelmesh-runtime-adapter/tree/v0.11.0) |
-| REST Proxy | Supports inference requests using KServe V2 REST Predict Protocol | [v0.11.0](https://github.com/kserve/rest-proxy/tree/v0.11.0) |
+The following table shows the component versions for the latest ModelMesh Serving release (v0.11.2).
+
+| Component                 | Description                                                        | Upstream Revision                                                           |
+| ------------------------- | ------------------------------------------------------------------ | --------------------------------------------------------------------------- |
+| ModelMesh                 | Serves as a general-purpose model serving management/routing layer | [v0.11.2](https://github.com/kserve/modelmesh/tree/v0.11.2)                 |
+| ModelMesh Runtime Adapter | Contains the unified puller/runtime-adapter image                  | [v0.11.2](https://github.com/kserve/modelmesh-runtime-adapter/tree/v0.11.2) |
+| REST Proxy                | Supports inference requests using KServe V2 REST Predict Protocol  | [v0.11.2](https://github.com/kserve/rest-proxy/tree/v0.11.2)                |

--- a/docs/install/install-script.md
+++ b/docs/install/install-script.md
@@ -43,11 +43,11 @@ A secret named `model-serving-etcd` will be created and passed to the controller
 <!-- Remove the following note on the `release-*` branch -->
 
 To install the most recent _stable release_ of [modelmesh-serving](https://github.com/kserve/modelmesh-serving/releases/latest)
-follow the [Installation instructions](https://github.com/kserve/modelmesh-serving/blob/release-0.11/docs/install/install-script.md) for version `v0.11.0`.
+follow the [Installation instructions](https://github.com/kserve/modelmesh-serving/blob/release-0.11.2/docs/install/install-script.md) for version `v0.11.2`.
 
 Start by cloning the [modelmesh-serving](https://github.com/kserve/modelmesh-serving.git) repository:
 
-<!-- Replace with RELEASE="release-0.11" on the `release-*` branch -->
+<!-- Replace with RELEASE="release-0.12" on the `release-0.12` branch -->
 
 ```shell
 RELEASE="main"

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,19 +4,24 @@ To quickly get started using ModelMesh Serving, here is a brief guide.
 
 <!-- Remove the following note on the `release-*` branch -->
 
-> **Note**: This document describes how to install the _latest unreleased_ version of ModelMesh for developers and early adopters. To install the most recent _stable release_, please follow the [Quick Start Guide for version 0.11](https://github.com/kserve/modelmesh-serving/blob/release-0.11/docs/quickstart.md).
+> **Note**: This document describes how to install the _latest unreleased_
+> version of ModelMesh for developers and early adopters. To install the
+> most recent _stable release_, please follow the
+> [Quick Start Guide for version 0.11.2](https://github.com/kserve/modelmesh-serving/blob/release-0.11.2/docs/quickstart.md).
 
 ## Prerequisites
 
 - A Kubernetes cluster v1.23+ with cluster administrative privileges
-- [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) and [kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/) (v4.0+)
-- At least 4 vCPU and 8 GB memory. For more details, please see [here](install/README.md#deployed-components).
+- [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) and
+  [kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/) (v4.0+)
+- At least 4 vCPU and 8 GB memory. For more details, please see
+  [here](install/README.md#deployed-components).
 
 ## 1. Install ModelMesh Serving
 
 ### Clone the ModelMesh repository
 
-<!-- Replace with RELEASE="release-0.11" on the `release-*` branch -->
+<!-- Replace with RELEASE="release-0.12" on the `release-0.12` branch -->
 
 ```shell
 RELEASE="main"

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -113,6 +113,7 @@ with KServe.
 
    - [ ] [kserve/modelmesh](https://hub.docker.com/r/kserve/modelmesh/tags)
    - [ ] [kserve/modelmesh-minio-examples](https://hub.docker.com/r/kserve/modelmesh-minio-examples/tags)
+   - [ ] [kserve/modelmesh-minio-dev-examples](https://hub.docker.com/r/kserve/modelmesh-minio-dev-examples/tags)
    - [ ] [kserve/modelmesh-runtime-adapter](https://hub.docker.com/r/kserve/modelmesh-runtime-adapter/tags)
    - [ ] [kserve/rest-proxy](https://hub.docker.com/r/kserve/rest-proxy/tags)
 
@@ -122,6 +123,7 @@ with KServe.
    - `kserve/modelmesh`
    - `kserve/modelmesh-controller`
    - `kserve/modelmesh-minio-examples`
+   - `kserve/modelmesh-minio-dev-examples`
    - `kserve/modelmesh-runtime-adapter`
    - `kserve/rest-proxy`
 
@@ -129,8 +131,8 @@ with KServe.
 
    - [ ] `.github/workflows/fvt-base.yml`:
      - [ ] `docker pull kserve/modelmesh:v...`
-     - [ ] `docker pull kserve/modelmesh-minio-examples:v...`
      - [ ] `docker pull kserve/modelmesh-minio-dev-examples:v...`
+     - [ ] `docker pull kserve/modelmesh-minio-examples:v...`
      - [ ] `docker pull kserve/modelmesh-runtime-adapter:v...`
      - [ ] `docker pull kserve/rest-proxy:v...`
    - [ ] `config/default/config-defaults.yaml`:
@@ -138,8 +140,8 @@ with KServe.
      - [ ] `kserve/rest-proxy`
      - [ ] `kserve/modelmesh-runtime-adapter`
    - [ ] `config/dependencies/fvt.yaml`:
-      - [ ] `image: kserve/modelmesh-minio-dev-examples:v...`
-      - [ ] `image: kserve/modelmesh-minio-examples:v...`
+     - [ ] `image: kserve/modelmesh-minio-dev-examples:v...`
+     - [ ] `image: kserve/modelmesh-minio-examples:v...`
    - [ ] `config/dependencies/quickstart.yaml`:
      - [ ] `image: kserve/modelmesh-minio-examples:v...`
    - [ ] `config/manager/kustomization.yaml`: update the `newTag` to `v...`
@@ -166,9 +168,9 @@ with KServe.
    (e.g. `v0.11.0`) with the new release branch name or new version tags.
    Submit them in a PR to `main`, and wait for that PR to be merged:
 
+   - [ ] `docs/install/install-script.md`
    - [ ] `docs/component-versions.md`
    - [ ] `docs/quickstart.md`
-   - [ ] `docs/install/install-script.md`
    - [ ] `scripts/setup_user_namespaces.sh`
 
 ## Generate Release Artifacts and Publish the Release

--- a/scripts/setup_user_namespaces.sh
+++ b/scripts/setup_user_namespaces.sh
@@ -31,7 +31,7 @@ EOF
 
 ctrl_ns="modelmesh-serving"
 user_ns_array=()
-modelmesh_release="v0.11.0"       # The latest release is the default
+modelmesh_release="v0.11.2"       # The latest release is the default
 create_storage_secret=false
 deploy_serving_runtimes=false
 dev_mode=false                    # Set to true to use locally cloned files instead of from a release


### PR DESCRIPTION
#### Motivation

Doc updates post `v0.11.2` release as instructed in the [release process](https://github.com/kserve/modelmesh-serving/blob/main/docs/release-process.md#update-release-tags):

#### Modifications

5. Update the following files in the `main` branch, replacing all occurrences
   pointing to the old `release-*` branch or the previous release version tag
   (e.g. `v0.11.2`) with the new release branch name or new version tags.
   Submit them in a PR to `main`, and wait for that PR to be merged:

   - [x] `docs/install/install-script.md`
   - [x] `docs/component-versions.md`
   - [x] `docs/quickstart.md`
   - [x] `scripts/setup_user_namespaces.sh`

#### Result

Docs will be current