### PR TITLE
docs: Update model support with Triton's FIL backend

### DIFF
--- a/docs/model-formats/README.md
+++ b/docs/model-formats/README.md
@@ -12,15 +12,15 @@ By leveraging existing third-party model servers, we support a number of standar
 - [XGBoost](xgboost.md)
 
 | Model Type  | Framework        | Supported via ServingRuntime |
-| ----------- | ---------------- | ---------------------------- |
-| keras       | TensorFlow       | Triton (C++)                 |
-| lightgbm    | LightGBM         | MLServer (python)            |
-| onnx        | ONNX             | Triton (C++), OVMS (C++)     |
-| openvino_ir | Intel OpenVINO\* | OVMS (C++)                   |
-| pytorch     | PyTorch          | Triton (C++)                 |
-| sklearn     | scikit-learn     | MLServer (python)            |
-| tensorflow  | TensorFlow       | Triton (C++)                 |
-| xgboost     | XGBoost          | MLServer (python)            |
-| any         | Custom           | [Custom](../runtimes) (any)  |
+| ----------- | ---------------- |------------------------------|
+| keras       | TensorFlow       | Triton                       |
+| lightgbm    | LightGBM         | MLServer, Triton             |
+| onnx        | ONNX             | Triton, OVMS                 |
+| openvino_ir | Intel OpenVINO\* | OVMS                         |
+| pytorch     | PyTorch          | Triton                       |
+| sklearn     | scikit-learn     | MLServer, Triton             |
+| tensorflow  | TensorFlow       | Triton                       |
+| xgboost     | XGBoost          | MLServer, Triton             |
+| any         | Custom           | [Custom](../runtimes)        |
 
 (\*)Many ML frameworks can have models converted to the OpenVINO IR format, such as Caffe, TensorFlow, MXNet, PaddlePaddle and ONNX, doc [here](https://docs.openvino.ai/latest/ovms_what_is_openvino_model_server.html).


### PR DESCRIPTION
#### Motivation
Triton introduced [support for more model frameworks last year](https://developer.nvidia.com/blog/real-time-serving-for-xgboost-scikit-learn-randomforest-lightgbm-and-more/). 

#### Modifications
- Update the supported models doc
- Doc how to deploy the out-of-the-box example models using Triton which depends on https://github.com/kserve/modelmesh-minio-examples/pull/7. 

#### Result
Closes #185 