### PR TITLE
release: Update v0.12.0-rc0 version references

### DIFF
--- a/.github/workflows/fvt-base.yml
+++ b/.github/workflows/fvt-base.yml
@@ -110,11 +110,11 @@ jobs:
           docker pull seldonio/mlserver:1.3.2
           docker pull openvino/model_server:2022.2
           # docker pull pytorch/torchserve:0.7.1-cpu
-          docker pull kserve/modelmesh:latest
-          docker pull kserve/modelmesh-minio-dev-examples:latest
-          docker pull kserve/modelmesh-minio-examples:latest
-          docker pull kserve/modelmesh-runtime-adapter:latest
-          docker pull kserve/rest-proxy:latest
+          docker pull kserve/modelmesh:v0.12.0-rc0
+          docker pull kserve/modelmesh-minio-dev-examples:v0.12.0-rc0
+          docker pull kserve/modelmesh-minio-examples:v0.12.0-rc0
+          docker pull kserve/modelmesh-runtime-adapter:v0.12.0-rc0
+          docker pull kserve/rest-proxy:v0.12.0-rc0
 
       - name: Check installation
         run: |

--- a/config/default/config-defaults.yaml
+++ b/config/default/config-defaults.yaml
@@ -16,7 +16,7 @@ podsPerRuntime: 2
 headlessService: true
 modelMeshImage:
   name: kserve/modelmesh
-  tag: latest
+  tag: v0.12.0-rc0
 modelMeshResources:
   requests:
     cpu: "300m"
@@ -29,7 +29,7 @@ restProxy:
   port: 8008
   image:
     name: kserve/rest-proxy
-    tag: latest
+    tag: v0.12.0-rc0
   resources:
     requests:
       cpu: "50m"
@@ -39,7 +39,7 @@ restProxy:
       memory: "512Mi"
 storageHelperImage:
   name: kserve/modelmesh-runtime-adapter
-  tag: latest
+  tag: v0.12.0-rc0
   command: ["/opt/app/puller"]
 storageHelperResources:
   requests:

--- a/config/dependencies/fvt.yaml
+++ b/config/dependencies/fvt.yaml
@@ -108,7 +108,7 @@ spec:
               value: AKIAIOSFODNN7EXAMPLE
             - name: MINIO_SECRET_KEY
               value: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-          image: kserve/modelmesh-minio-dev-examples:latest
+          image: kserve/modelmesh-minio-dev-examples:v0.12.0-rc0
           name: minio
 ---
 apiVersion: v1
@@ -171,7 +171,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: "copy-pod"
-          image: kserve/modelmesh-minio-examples:latest
+          image: kserve/modelmesh-minio-examples:v0.12.0-rc0
           securityContext:
             runAsUser: 0
             allowPrivilegeEscalation: false

--- a/config/dependencies/quickstart.yaml
+++ b/config/dependencies/quickstart.yaml
@@ -110,7 +110,7 @@ spec:
             - name: MINIO_SECRET_KEY
               value: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
           # image: quay.io/cloudservices/minio:latest
-          image: kserve/modelmesh-minio-examples:latest
+          image: kserve/modelmesh-minio-examples:v0.12.0-rc0
           name: minio
 ---
 apiVersion: v1

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -18,4 +18,4 @@ images:
   - name: modelmesh-controller
     newName: kserve/modelmesh-controller
     ## NOTE THIS SHOULD BE REPLACED WITH LATEST CONTROLLER IMAGE TAG
-    newTag: latest
+    newTag: v0.12.0-rc0

--- a/docs/component-versions.md
+++ b/docs/component-versions.md
@@ -1,9 +1,9 @@
 # Component versions
 
-The following table shows the component versions for the latest ModelMesh Serving release (v0.11.2).
+The following table shows the component versions for the latest ModelMesh Serving release (v0.12.0-rc0).
 
-| Component                 | Description                                                        | Upstream Revision                                                           |
-| ------------------------- | ------------------------------------------------------------------ | --------------------------------------------------------------------------- |
-| ModelMesh                 | Serves as a general-purpose model serving management/routing layer | [v0.11.2](https://github.com/kserve/modelmesh/tree/v0.11.2)                 |
-| ModelMesh Runtime Adapter | Contains the unified puller/runtime-adapter image                  | [v0.11.2](https://github.com/kserve/modelmesh-runtime-adapter/tree/v0.11.2) |
-| REST Proxy                | Supports inference requests using KServe V2 REST Predict Protocol  | [v0.11.2](https://github.com/kserve/rest-proxy/tree/v0.11.2)                |
+| Component                 | Description                                                        | Upstream Revision                                                                   |
+| ------------------------- | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
+| ModelMesh                 | Serves as a general-purpose model serving management/routing layer | [v0.12.0-rc0](https://github.com/kserve/modelmesh/tree/v0.12.0-rc0)                 |
+| ModelMesh Runtime Adapter | Contains the unified puller/runtime-adapter image                  | [v0.12.0-rc0](https://github.com/kserve/modelmesh-runtime-adapter/tree/v0.12.0-rc0) |
+| REST Proxy                | Supports inference requests using KServe V2 REST Predict Protocol  | [v0.12.0-rc0](https://github.com/kserve/rest-proxy/tree/v0.12.0-rc0)                |

--- a/docs/install/install-script.md
+++ b/docs/install/install-script.md
@@ -40,17 +40,10 @@ A secret named `model-serving-etcd` will be created and passed to the controller
 
 ## Installation
 
-<!-- Remove the following note on the `release-*` branch -->
-
-To install the most recent _stable release_ of [modelmesh-serving](https://github.com/kserve/modelmesh-serving/releases/latest)
-follow the [Installation instructions](https://github.com/kserve/modelmesh-serving/blob/release-0.11.2/docs/install/install-script.md) for version `v0.11.2`.
-
 Start by cloning the [modelmesh-serving](https://github.com/kserve/modelmesh-serving.git) repository:
 
-<!-- Replace with RELEASE="release-0.12" on the `release-0.12` branch -->
-
 ```shell
-RELEASE="main"
+RELEASE="release-0.12"
 git clone -b $RELEASE --depth 1 --single-branch https://github.com/kserve/modelmesh-serving.git
 cd modelmesh-serving
 ```
@@ -103,7 +96,7 @@ The installation will create a secret named `storage-config` if it does not alre
 
 The `--namespace-scope-mode` will deploy `ServingRuntime`s confined to the same namespace, instead of the default cluster-scoped runtimes `ClusterServingRuntime`s. These serving runtimes are accessible to any user/namespace in the cluster.
 
-You can optionally provide a custom ModelMesh Serving image with `--modelmesh-serving-image`. If not specified, it will pull the latest image.
+You can optionally provide a custom ModelMesh Serving image with `--modelmesh-serving-image`. If not specified, it will pull the v0.12.0-rc0 image.
 
 The ModelMesh controller uses a webhook that requires a certificate. We suggest using [cert-manager](https://github.com/cert-manager/cert-manager) to provision the certificates for the webhook server. Other solutions should also work as long as they put the certificates in the desired location. You can follow [the cert-manager documentation](https://cert-manager.io/docs/installation/) to install it.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,13 +2,6 @@
 
 To quickly get started using ModelMesh Serving, here is a brief guide.
 
-<!-- Remove the following note on the `release-*` branch -->
-
-> **Note**: This document describes how to install the _latest unreleased_
-> version of ModelMesh for developers and early adopters. To install the
-> most recent _stable release_, please follow the
-> [Quick Start Guide for version 0.11.2](https://github.com/kserve/modelmesh-serving/blob/release-0.11.2/docs/quickstart.md).
-
 ## Prerequisites
 
 - A Kubernetes cluster v1.23+ with cluster administrative privileges
@@ -22,10 +15,8 @@ To quickly get started using ModelMesh Serving, here is a brief guide.
 
 ### Clone the ModelMesh repository
 
-<!-- Replace with RELEASE="release-0.12" on the `release-0.12` branch -->
-
 ```shell
-RELEASE="main"
+RELEASE="release-0.12"
 git clone -b $RELEASE --depth 1 --single-branch https://github.com/kserve/modelmesh-serving.git
 cd modelmesh-serving
 ```

--- a/scripts/setup_user_namespaces.sh
+++ b/scripts/setup_user_namespaces.sh
@@ -31,7 +31,7 @@ EOF
 
 ctrl_ns="modelmesh-serving"
 user_ns_array=()
-modelmesh_release="v0.11.2"       # The latest release is the default
+modelmesh_release="v0.12.0-rc0"       # The latest release is the default
 create_storage_secret=false
 deploy_serving_runtimes=false
 dev_mode=false                    # Set to true to use locally cloned files instead of from a release


### PR DESCRIPTION
#### Motivation

Preparation for `v0.12.0-rc0` release.

#### Modifications

Version references updated in the following files:

   - [x] `.github/workflows/fvt-base.yml`
   - [x] `config/default/config-defaults.yaml`
   - [x] `config/dependencies/fvt.yaml`
   - [x] `config/dependencies/quickstart.yaml`
   - [x] `config/manager/kustomization.yaml`
   - [x] `docs/component-versions.md`
   - [x] `docs/install/install-script.md`
   - [x] `docs/quickstart.md`
   - [x] `scripts/setup_user_namespaces.sh`

#### Result

