### PR TITLE
docs: Update version tags after v0.12.0 release

### DIFF
--- a/docs/component-versions.md
+++ b/docs/component-versions.md
@@ -1,9 +1,9 @@
 # Component versions
 
-The following table shows the component versions for the latest ModelMesh Serving release (v0.11.2).
+The following table shows the component versions for the latest ModelMesh Serving release (v0.12.0).
 
 | Component                 | Description                                                        | Upstream Revision                                                           |
-| ------------------------- | ------------------------------------------------------------------ | --------------------------------------------------------------------------- |
-| ModelMesh                 | Serves as a general-purpose model serving management/routing layer | [v0.11.2](https://github.com/kserve/modelmesh/tree/v0.11.2)                 |
-| ModelMesh Runtime Adapter | Contains the unified puller/runtime-adapter image                  | [v0.11.2](https://github.com/kserve/modelmesh-runtime-adapter/tree/v0.11.2) |
-| REST Proxy                | Supports inference requests using KServe V2 REST Predict Protocol  | [v0.11.2](https://github.com/kserve/rest-proxy/tree/v0.11.2)                |
+| ------------------------- | ------------------------------------------------------------------ |-----------------------------------------------------------------------------|
+| ModelMesh                 | Serves as a general-purpose model serving management/routing layer | [v0.12.0](https://github.com/kserve/modelmesh/tree/v0.12.0)                 |
+| ModelMesh Runtime Adapter | Contains the unified puller/runtime-adapter image                  | [v0.12.0](https://github.com/kserve/modelmesh-runtime-adapter/tree/v0.12.0) |
+| REST Proxy                | Supports inference requests using KServe V2 REST Predict Protocol  | [v0.12.0](https://github.com/kserve/rest-proxy/tree/v0.12.0)                |

--- a/docs/install/install-script.md
+++ b/docs/install/install-script.md
@@ -43,11 +43,11 @@ A secret named `model-serving-etcd` will be created and passed to the controller
 <!-- Remove the following note on the `release-*` branch -->
 
 To install the most recent _stable release_ of [modelmesh-serving](https://github.com/kserve/modelmesh-serving/releases/latest)
-follow the [Installation instructions](https://github.com/kserve/modelmesh-serving/blob/release-0.11.2/docs/install/install-script.md) for version `v0.11.2`.
+follow the [Installation instructions](https://github.com/kserve/modelmesh-serving/blob/release-0.12.0/docs/install/install-script.md) for version `v0.12.0`.
 
 Start by cloning the [modelmesh-serving](https://github.com/kserve/modelmesh-serving.git) repository:
 
-<!-- Replace with RELEASE="release-0.12" on the `release-0.12` branch -->
+<!-- Replace with RELEASE="release-0.13" on the `release-0.13` branch -->
 
 ```shell
 RELEASE="main"

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,7 +7,7 @@ To quickly get started using ModelMesh Serving, here is a brief guide.
 > **Note**: This document describes how to install the _latest unreleased_
 > version of ModelMesh for developers and early adopters. To install the
 > most recent _stable release_, please follow the
-> [Quick Start Guide for version 0.11.2](https://github.com/kserve/modelmesh-serving/blob/release-0.11.2/docs/quickstart.md).
+> [Quick Start Guide for version 0.12.0](https://github.com/kserve/modelmesh-serving/blob/release-0.12.0/docs/quickstart.md).
 
 ## Prerequisites
 
@@ -22,7 +22,7 @@ To quickly get started using ModelMesh Serving, here is a brief guide.
 
 ### Clone the ModelMesh repository
 
-<!-- Replace with RELEASE="release-0.12" on the `release-0.12` branch -->
+<!-- Replace with RELEASE="release-0.13" on the `release-0.13` branch -->
 
 ```shell
 RELEASE="main"

--- a/scripts/setup_user_namespaces.sh
+++ b/scripts/setup_user_namespaces.sh
@@ -31,7 +31,7 @@ EOF
 
 ctrl_ns="modelmesh-serving"
 user_ns_array=()
-modelmesh_release="v0.11.2"       # The latest release is the default
+modelmesh_release="v0.12.0"       # The latest release is the default
 create_storage_secret=false
 deploy_serving_runtimes=false
 dev_mode=false                    # Set to true to use locally cloned files instead of from a release


### PR DESCRIPTION
#### Motivation

Doc updates post v0.12.0 release.

#### Modifications

Update the following files in the `main` branch, replacing all occurrences
   pointing to the old `release-*` branch or the previous release version tag
   (e.g. `v0.11.0`) with the new release branch name or new version tags.
   Submit them in a PR to `main`, and wait for that PR to be merged:

   - [x] `docs/install/install-script.md`
   - [x] `docs/component-versions.md`
   - [x] `docs/quickstart.md`
   - [x] `scripts/setup_user_namespaces.sh`

#### Result

Docs will warn users to use docs of latest release, rather than `main` docs.