### PR TITLE
feat: add S390x support in affinity rule

### DIFF
--- a/controllers/modelmesh/runtime.go
+++ b/controllers/modelmesh/runtime.go
@@ -341,7 +341,7 @@ func addDomainSocketMount(rts *kserveapi.ServingRuntimeSpec, c *corev1.Container
 func (m *Deployment) addPassThroughPodFieldsToDeployment(deployment *appsv1.Deployment) error {
 	rts := m.SRSpec
 	// these fields map directly to pod spec fields
-	// supported architectures are "amd64", "arm64" and "s390x" 
+	// supported architectures are "amd64", "arm64" and "s390x"
 	deployment.Spec.Template.Spec.NodeSelector = rts.NodeSelector
 	deployment.Spec.Template.Spec.Tolerations = rts.Tolerations
 	archNodeSelector := corev1.NodeSelectorTerm{

--- a/controllers/modelmesh/runtime.go
+++ b/controllers/modelmesh/runtime.go
@@ -341,8 +341,7 @@ func addDomainSocketMount(rts *kserveapi.ServingRuntimeSpec, c *corev1.Container
 func (m *Deployment) addPassThroughPodFieldsToDeployment(deployment *appsv1.Deployment) error {
 	rts := m.SRSpec
 	// these fields map directly to pod spec fields
-	// supported architectures are "amd64" and "arm64", "ppc64le"
-	// and "s390x" 
+	// supported architectures are "amd64", "arm64", "s390x" 
 	deployment.Spec.Template.Spec.NodeSelector = rts.NodeSelector
 	deployment.Spec.Template.Spec.Tolerations = rts.Tolerations
 	archNodeSelector := corev1.NodeSelectorTerm{

--- a/controllers/modelmesh/runtime.go
+++ b/controllers/modelmesh/runtime.go
@@ -341,7 +341,7 @@ func addDomainSocketMount(rts *kserveapi.ServingRuntimeSpec, c *corev1.Container
 func (m *Deployment) addPassThroughPodFieldsToDeployment(deployment *appsv1.Deployment) error {
 	rts := m.SRSpec
 	// these fields map directly to pod spec fields
-	// supported architectures are "amd64", "arm64", "s390x" 
+	// supported architectures are "amd64", "arm64" and "s390x" 
 	deployment.Spec.Template.Spec.NodeSelector = rts.NodeSelector
 	deployment.Spec.Template.Spec.Tolerations = rts.Tolerations
 	archNodeSelector := corev1.NodeSelectorTerm{

--- a/controllers/modelmesh/runtime.go
+++ b/controllers/modelmesh/runtime.go
@@ -342,8 +342,7 @@ func (m *Deployment) addPassThroughPodFieldsToDeployment(deployment *appsv1.Depl
 	rts := m.SRSpec
 	// these fields map directly to pod spec fields
 	// supported architectures are "amd64" and "arm64", "ppc64le"
-	// and "s390x" are not supported by tensorflow
-	// (https://github.com/kserve/modelmesh-runtime-adapter/pull/38#discussion_r1156749259)
+	// and "s390x" 
 	deployment.Spec.Template.Spec.NodeSelector = rts.NodeSelector
 	deployment.Spec.Template.Spec.Tolerations = rts.Tolerations
 	archNodeSelector := corev1.NodeSelectorTerm{
@@ -351,7 +350,7 @@ func (m *Deployment) addPassThroughPodFieldsToDeployment(deployment *appsv1.Depl
 			{
 				Key:      "kubernetes.io/arch",
 				Operator: corev1.NodeSelectorOpIn,
-				Values:   []string{"amd64", "arm64"},
+				Values:   []string{"amd64", "arm64", "s390x"},
 			},
 		},
 	}

--- a/controllers/testdata/servingruntime_controller.golden
+++ b/controllers/testdata/servingruntime_controller.golden
@@ -293,6 +293,7 @@ spec:
                 values:
                 - amd64
                 - arm64
+                - s390x
       containers:
       - command:
         - /opt/app/mlserver-adapter
@@ -543,6 +544,7 @@ spec:
                 values:
                 - amd64
                 - arm64
+                - s390x
       containers:
       - env:
         - name: REST_PROXY_LISTEN_PORT
@@ -815,6 +817,7 @@ spec:
                 values:
                 - amd64
                 - arm64
+                - s390x
       containers:
       - command:
         - /opt/app/mlserver-adapter
@@ -1062,6 +1065,7 @@ spec:
                 values:
                 - amd64
                 - arm64
+                - s390x
       containers:
       - command:
         - /opt/app/ovms-adapter
@@ -1301,6 +1305,7 @@ spec:
                 values:
                 - amd64
                 - arm64
+                - s390x
       containers:
       - command:
         - /opt/app/torchserve-adapter
@@ -1543,6 +1548,7 @@ spec:
                 values:
                 - amd64
                 - arm64
+                - s390x
       containers:
       - command:
         - /opt/app/triton-adapter
@@ -1800,6 +1806,7 @@ spec:
                 values:
                 - amd64
                 - arm64
+                - s390x
       containers:
       - env:
         - name: MODEL_DIRECTORY_PATH

--- a/controllers/testdata/servingruntime_controller.golden
+++ b/controllers/testdata/servingruntime_controller.golden
@@ -38,6 +38,7 @@ spec:
                 values:
                 - amd64
                 - arm64
+                - s390x
       containers:
       - command:
         - /opt/app/mlserver-adapter


### PR DESCRIPTION
Added s390x in node affinity rule as already work is going on to support s390x for tensorflow in runtime-adaptor 
