### PR TITLE
Update Dockerfile.develop

### DIFF
--- a/Dockerfile.develop
+++ b/Dockerfile.develop
@@ -76,8 +76,10 @@ ARG TARGETARCH
 
 ARG OPENSHIFT_VERSION=4.12
 ARG KUSTOMIZE_VERSION=4.5.2
-ARG KUBEBUILDER_VERSION=v3.11.0
+ARG KUBEBUILDER_VERSION=v3.14.0
 ARG CONTROLLER_GEN_VERSION=v0.11.4
+ARG ETCD_VERSION=v3.5.6
+ARG APISERVER_VERSION=v1.25.0
 
 ENV PATH=/usr/local/go/bin:$PATH:/usr/local/kubebuilder/bin:
 
@@ -102,13 +104,29 @@ ENV PIP_CACHE_DIR=/root/.cache/pip
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip install pre-commit
 
-# First download and extract older dist of kubebuilder which includes required etcd, kube-apiserver and kubectl binaries
-# Then download and overwrite kubebuilder binary with desired/latest version
+#Older version of kubebuilder doesn't have s390x tar file. Individually installing etcd , kube-apiserver , kubebuilder , kubectl for all architecture (amd64, arm64 , pp64cle & s390x)
 RUN true \
-    && curl -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v2.3.2/kubebuilder_2.3.2_${TARGETOS:-linux}_${TARGETARCH:-amd64}.tar.gz | tar -xz -C /tmp/ \
-    && mv /tmp/kubebuilder_*_${TARGETOS:-linux}_${TARGETARCH:-amd64} /usr/local/kubebuilder \
+    && mkdir -p /usr/local/kubebuilder/bin \
     && curl -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/${KUBEBUILDER_VERSION}/kubebuilder_${TARGETOS:-linux}_${TARGETARCH:-amd64} -o /usr/local/kubebuilder/bin/kubebuilder \
+    && chmod +x /usr/local/kubebuilder/bin/kubebuilder \
     && true
+
+RUN true \
+    && wget https://dl.k8s.io/${APISERVER_VERSION}/bin/${TARGETOS:-linux}/${TARGETARCH:-amd64}/kube-apiserver \
+    && mv kube-apiserver /usr/local/kubebuilder/bin \
+    && chmod +x /usr/local/kubebuilder/bin/kube-apiserver \
+    && kube-apiserver --version \
+    && true
+
+ENV PATH=/usr/local/go/bin:$PATH:/usr/local/kubebuilder/bin/etcd-${ETCD_VERSION}-${TARGETOS:-linux}-${TARGETARCH:-amd64}:
+
+RUN true \
+   && wget https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-${TARGETOS:-linux}-${TARGETARCH:-amd64}.tar.gz \
+   && tar -C /usr/local/kubebuilder/bin -xvzf etcd-${ETCD_VERSION}-${TARGETOS:-linux}-${TARGETARCH:-amd64}.tar.gz \
+   && chmod +x /usr/local/kubebuilder/bin/etcd-${ETCD_VERSION}-${TARGETOS:-linux}-${TARGETARCH:-amd64}/etcd \
+   && etcd --version \
+   && true
+
 
 # Download openshift-cli
 RUN true \
@@ -158,10 +176,10 @@ RUN true \
     && ginkgo version \
     && true
 
-# Use setup-envtest for kubebuilder to use K8s version 1.23+ for autoscaling/v2 (HPA)
+# Use setup-envtest for kubebuilder to use K8s version 1.23+ for autoscaling/v2 (HPA).kubebuilder tool 1.29 works fine with s390x & other architecture
 RUN true \
     && go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest \
-    && setup-envtest use 1.26 \
+    && setup-envtest use 1.29 \
     && true
 
 # For GitHub Action 'lint', work around error "detected dubious ownership in repository at '/workspace'"


### PR DESCRIPTION
Updated kubebuilder ,envtest for s390x. I am able to build the developer image successfully on s390x. I have added small snapshot below 
```
[root@m1305001 modelmesh-serving]# make run fmt
make: go: Command not found
which: no controller-gen in (/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin)
Makefile:216: warning: overriding recipe for target 'fmt'
Makefile:153: warning: ignoring old recipe for target 'fmt'
./scripts/build_devimage.sh "podman"
/usr/bin/sha1sum
Pulling dev image kserve/modelmesh-controller-develop:9f6853f0cc3268cb...
Image kserve/modelmesh-controller-develop:9f6853f0cc3268cb does not exist yet
Building dev image kserve/modelmesh-controller-develop:9f6853f0cc3268cb
[1/2] STEP 1/9: FROM registry.access.redhat.com/ubi8/ubi-minimal:8.9 AS go-toolset
[1/2] STEP 2/9: ARG TARGETOS
--> Using cache b0ca21c485d0f83033c13da6d1311c30e2631ca6e0066f9cf139b82b7b642479
--> b0ca21c485d0
[1/2] STEP 3/9: ARG TARGETARCH
--> Using cache 88086c84e4af70f942ad6a10c0a383e8422f64f13fcfd6b67c83f18045217bb4
--> 88086c84e4af
[1/2] STEP 4/9: ARG GOLANG_VERSION=1.21.6
--> Using cache 0676771de5fa097afebd0a36550778231d56ce13ba4b5a5546d604d0887b1d2e
--> 0676771de5fa
.....
....
[2/2] STEP 28/31: RUN true     && go install github.com/onsi/ginkgo/v2/ginkgo     && ginkgo version     && true
Ginkgo Version 2.13.0
--> 891c5c632c98
[2/2] STEP 29/31: RUN true     && go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest     && setup-envtest use 1.29     && true
go: downloading sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20240516231036-f4ca78ebc00a
go: downloading sigs.k8s.io/controller-runtime v0.18.2
go: sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20240516231036-f4ca78ebc00a requires go >= 1.22.0; switching to go1.22.3
go: downloading go1.22.3 (linux/s390x)
go: downloading github.com/go-logr/zapr v1.2.4
go: downloading github.com/spf13/afero v1.6.0
go: downloading github.com/go-logr/logr v1.2.4
go: downloading golang.org/x/text v0.12.0
go: downloading go.uber.org/multierr v1.10.0
Version: 1.29.3
OS/Arch: linux/s390x
md5: 6FYdZY5YRV6GoxBEQfc/IQ==
Path: /root/.local/share/kubebuilder-envtest/k8s/1.29.3-linux-s390x
--> b8e38d2752bd
[2/2] STEP 30/31: RUN git config --system --add safe.directory /workspace
--> 8f801c4cf95c
[2/2] STEP 31/31: CMD /bin/bash
[2/2] COMMIT kserve/modelmesh-controller-develop:b6daac75d8d3248c
--> bf58bb0633ef
Successfully tagged localhost/kserve/modelmesh-controller-develop:b6daac75d8d3248c
bf58bb0633efd5a0755374845235ea5542be3090ce0fb2a0493919dc61920835
Image kserve/modelmesh-controller-develop:b6daac75d8d3248c has 62 layers
Tagging dev image kserve/modelmesh-controller-develop:b6daac75d8d3248c as latest
```  
