### PR TITLE
docs: changed every instance of default_bucket to bucket

### DIFF
--- a/config/default/storage-secret.yaml
+++ b/config/default/storage-secret.yaml
@@ -27,5 +27,5 @@ metadata:
 #       "secret_access_key": "abcdff6a11223344aabbcc66ee231e6dd0c1122ff1234567",
 #       "endpoint_url": "https://s3.us-south.cloud-object-storage.appdomain.cloud",
 #       "region": "us-south",
-#       "default_bucket": "modelmesh-example-public"
+#       "bucket": "modelmesh-example-public"
 #     }

--- a/config/dependencies/fvt.yaml
+++ b/config/dependencies/fvt.yaml
@@ -122,7 +122,7 @@ stringData:
       "access_key_id": "AKIAIOSFODNN7EXAMPLE",
       "secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
       "endpoint_url": "http://minio:9000",
-      "default_bucket": "modelmesh-example-models",
+      "bucket": "modelmesh-example-models",
       "region": "us-south"
     }
 ---

--- a/config/dependencies/minio-storage-secret.yaml
+++ b/config/dependencies/minio-storage-secret.yaml
@@ -22,6 +22,6 @@ stringData:
       "access_key_id": "AKIAIOSFODNN7EXAMPLE",
       "secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
       "endpoint_url": "http://minio.controller_namespace:9000",
-      "default_bucket": "modelmesh-example-models",
+      "bucket": "modelmesh-example-models",
       "region": "us-south"
     }

--- a/config/dependencies/quickstart.yaml
+++ b/config/dependencies/quickstart.yaml
@@ -124,6 +124,6 @@ stringData:
       "access_key_id": "AKIAIOSFODNN7EXAMPLE",
       "secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
       "endpoint_url": "http://minio:9000",
-      "default_bucket": "modelmesh-example-models",
+      "bucket": "modelmesh-example-models",
       "region": "us-south"
     }

--- a/docs/predictors/README.md
+++ b/docs/predictors/README.md
@@ -28,7 +28,7 @@ There should be secret key called `localMinIO` that looks like:
   "access_key": "AKIAIOSFODNN7EXAMPLE",
   "secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
   "endpoint_url": "http://minio:9000",
-  "default_bucket": "modelmesh-example-models"
+  "bucket": "modelmesh-example-models"
 }
 ```
 

--- a/docs/predictors/setup-storage.md
+++ b/docs/predictors/setup-storage.md
@@ -60,7 +60,7 @@ $ mc ls myminio/models/onnx
 
 ### 3. Add a storage entry to the `storage-config` secret
 
-Ensure there is a key defined in the common `storage-config` secret corresponding to the S3-based storage instance holding your model. The value of this secret key should be JSON like the following, `default_bucket` is optional.
+Ensure there is a key defined in the common `storage-config` secret corresponding to the S3-based storage instance holding your model. The value of this secret key should be JSON like the following, `bucket` is optional.
 
 Users can specify use of a custom certificate via the storage config `certificate` parameter. The custom certificate should be in the form of an embedded Certificate Authority (CA) bundle in PEM format.
 
@@ -72,7 +72,7 @@ Using MinIO the JSON contents look like:
   "access_key_id": "minioadmin",
   "secret_access_key": "minioadmin/K7JTCMP/EXAMPLEKEY",
   "endpoint_url": "http://127.0.0.1:9000:9000",
-  "default_bucket": "",
+  "bucket": "",
   "region": "us-east"
 }
 ```
@@ -207,7 +207,7 @@ stringData:
 #      "access_key_id": "AKIAIOSFODNN7EXAMPLE",
 #      "secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
 #      "endpoint_url": "http://minio:9000",
-#      "default_bucket": "modelmesh-example-models",
+#      "bucket": "modelmesh-example-models",
 #      "region": "us-south"
 #    }
   pvc1: |

--- a/fvt/globals.go
+++ b/fvt/globals.go
@@ -46,7 +46,7 @@ var StorageConfigDataMinio = map[string]interface{}{
 		"access_key_id":     "AKIAIOSFODNN7EXAMPLE",
 		"secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
 		"endpoint_url":      "http://minio:9000",
-		"default_bucket":    "modelmesh-example-models",
+		"bucket":    "modelmesh-example-models",
 		"region":            "us-south",
 	},
 }

--- a/fvt/globals.go
+++ b/fvt/globals.go
@@ -46,7 +46,7 @@ var StorageConfigDataMinio = map[string]interface{}{
 		"access_key_id":     "AKIAIOSFODNN7EXAMPLE",
 		"secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
 		"endpoint_url":      "http://minio:9000",
-		"bucket":    "modelmesh-example-models",
+		"bucket":            "modelmesh-example-models",
 		"region":            "us-south",
 	},
 }


### PR DESCRIPTION
#### Motivation

Replacing default_bucket -> bucket everywhere in this repo to ensure it's consistent with KServe.

#### Modifications

replaced every instance of `default_bucket` to `bucket`

#### Result

Tested the [quickstart install](https://github.com/kserve/modelmesh-serving/blob/main/docs/quickstart.md) after modifying [quickstart.yaml](https://github.com/kserve/modelmesh-serving/blob/6c86da9473d50de63f9ea3af8a4d7c223849547e/config/dependencies/quickstart.yaml#L127) 

pods up and running - 

```
kubectl get pods
NAME                                              READY   STATUS    RESTARTS   AGE
etcd-6fdc487479-m9pkx                             1/1     Running   0          32m
minio-6b5c846587-8bwdv                            1/1     Running   0          32m
modelmesh-controller-5cd8d68bc-9ls9p              1/1     Running   0          31m
modelmesh-serving-mlserver-1.x-66bb94dcf6-hvgzj   4/4     Running   0          26m
modelmesh-serving-mlserver-1.x-66bb94dcf6-qtdzw   4/4     Running   0          26m
```

Model deployed and InferenceService is Ready - 

```
kubectl get isvc
NAME                   URL                                               READY   PREV   LATEST   PREVROLLEDOUTREVISION   LATESTREADYREVISION   AGE
example-sklearn-isvc   grpc://modelmesh-serving.modelmesh-serving:8033   True  
```

```
kubectl describe isvc example-sklearn-isvc
Name:         example-sklearn-isvc
Namespace:    modelmesh-serving
Labels:       <none>
Annotations:  serving.kserve.io/deploymentMode: ModelMesh
API Version:  serving.kserve.io/v1beta1
Kind:         InferenceService
Metadata:
  Creation Timestamp:  2024-05-28T07:19:00Z
  Generation:          1
  Resource Version:    5950
  UID:                 db71cf11-7842-4bc1-af97-647282e6b9b9
Spec:
  Predictor:
    Model:
      Model Format:
        Name:  sklearn
      Storage:
        Key:   localMinIO
        Path:  sklearn/mnist-svm.joblib
Status:
  Components:
    Predictor:
      Grpc URL:  grpc://modelmesh-serving.modelmesh-serving:8033
      Rest URL:  http://modelmesh-serving.modelmesh-serving:8008
      URL:       grpc://modelmesh-serving.modelmesh-serving:8033
  Conditions:
    Last Transition Time:  2024-05-28T07:25:07Z
    Status:                True
    Type:                  PredictorReady
    Last Transition Time:  2024-05-28T07:25:07Z
    Status:                True
    Type:                  Ready
  Model Status:
    Copies:
      Failed Copies:  0
      Total Copies:   1
    States:
      Active Model State:  Loaded
      Target Model State:  
    Transition Status:     UpToDate
  URL:                     grpc://modelmesh-serving.modelmesh-serving:8033
Events:                    <none>
```

Inference Request successful - 

```
MODEL_NAME=example-sklearn-isvc
grpcurl \
  -plaintext \
  -proto fvt/proto/kfs_inference_v2.proto \
  -d '{ "model_name": "'"${MODEL_NAME}"'", "inputs": [{ "name": "predict", "shape": [1, 64], "datatype": "FP32", "contents": { "fp32_contents": [0.0, 0.0, 1.0, 11.0, 14.0, 15.0, 3.0, 0.0, 0.0, 1.0, 13.0, 16.0, 12.0, 16.0, 8.0, 0.0, 0.0, 8.0, 16.0, 4.0, 6.0, 16.0, 5.0, 0.0, 0.0, 5.0, 15.0, 11.0, 13.0, 14.0, 0.0, 0.0, 0.0, 0.0, 2.0, 12.0, 16.0, 13.0, 0.0, 0.0, 0.0, 0.0, 0.0, 13.0, 16.0, 16.0, 6.0, 0.0, 0.0, 0.0, 0.0, 16.0, 16.0, 16.0, 7.0, 0.0, 0.0, 0.0, 0.0, 11.0, 13.0, 12.0, 1.0, 0.0] }}]}' \
  localhost:8033 \
  inference.GRPCInferenceService.ModelInfer

Handling connection for 8033
{
  "modelName": "example-sklearn-isvc__isvc-6b2eb0b8bf",
  "outputs": [
    {
      "name": "predict",
      "datatype": "INT64",
      "shape": [
        "1",
        "1"
      ],
      "contents": {
        "int64Contents": [
          "8"
        ]
      }
    }
  ]
}
```


This issue closes #456 