### PR TITLE
allow external hpa

### DIFF
--- a/config/internal/base/deployment.yaml.tmpl
+++ b/config/internal/base/deployment.yaml.tmpl
@@ -22,7 +22,9 @@ metadata:
     app.kubernetes.io/name: modelmesh-controller
     name: {{.ServiceName}}-{{.Name}}
 spec:
+  {{if ge .Replicas 0}}
   replicas: {{.Replicas}}
+  {{end}}
   selector:
     matchLabels:
       modelmesh-service: {{.ServiceName}}

--- a/controllers/autoscaler/autoscaler_reconciler.go
+++ b/controllers/autoscaler/autoscaler_reconciler.go
@@ -104,6 +104,10 @@ func createAutoscaler(client client.Client,
 		// Set HPA reconciler even though AutoscalerClass is None to delete existing hpa
 		as.HPA = hpa.NewHPAReconciler(client, scheme, runtimeMeta, mmDeploymentName, mmNamespace)
 		return as, nil
+	case constants.AutoscalerClassExternal:
+		// Set HPA reconciler even though AutoscalerClass is External to delete existing hpa
+		as.HPA = hpa.NewHPAReconciler(client, scheme, runtimeMeta, mmDeploymentName, mmNamespace)
+		return as, nil
 	default:
 		return nil, errors.New("unknown autoscaler class type.")
 	}

--- a/controllers/modelmesh/modelmesh.go
+++ b/controllers/modelmesh/modelmesh.go
@@ -66,7 +66,7 @@ type Deployment struct {
 	PullerImage         string
 	PullerImageCommand  []string
 	PullerResources     *corev1.ResourceRequirements
-	Replicas            uint16
+	Replicas            int32
 	Port                uint16
 	TLSSecretName       string
 	TLSClientAuth       string


### PR DESCRIPTION
#### Motivation

The current options for scaling are
- static based on replicas in the servingruntime/config
- dynamic using `hpa` annotation. But this creates a managed hpa that only works with the buildin kubernetes metrics. Adding another hpa will conflict with the already created one.

This PR adds the `external` option where the controller wont set the replicas and wont create an hpa.

#### Modifications

The already existing External AutoscalerClass is now checked for instead of crashing the controller. The behavior is the same as `None`  except it does not set the replicas property.

#### Result
