### PR TITLE
fix: Solve kustomize warning

### DIFF
--- a/config/namespace-runtimes/kustomization.yaml
+++ b/config/namespace-runtimes/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-bases:
+resources:
   - ../runtimes
 patches:
   - target:


### PR DESCRIPTION
Update namespace-runtimes kustomization to fix warning about `bases` is deprecated.

#### Motivation

Fix kustomize deprecated warning.

```
Warning: 'bases' is deprecated. Please use 'resources' instead.
Run 'kustomize edit fix' to update your Kustomization automatically.
```

#### Modifications

Replace `bases` by `resources`.

#### Result
