### PR TITLE
Add runtimeClass support to modelmesh deployment

### DIFF
--- a/config/default/config-defaults.yaml
+++ b/config/default/config-defaults.yaml
@@ -49,6 +49,7 @@ storageHelperResources:
     cpu: "2"
     memory: "512Mi"
 serviceAccountName: ""
+runtimeClassName: ""
 metrics:
   enabled: true
 builtInServerTypes:

--- a/controllers/modelmesh/modelmesh.go
+++ b/controllers/modelmesh/modelmesh.go
@@ -67,6 +67,7 @@ type Deployment struct {
 	PullerImageCommand  []string
 	PullerResources     *corev1.ResourceRequirements
 	Replicas            uint16
+	RuntimeClassName    string
 	Port                uint16
 	TLSSecretName       string
 	TLSClientAuth       string
@@ -131,6 +132,7 @@ func (m *Deployment) Apply(ctx context.Context) error {
 				m.configureRuntimePodSpecLabels,
 				m.ensureMMContainerIsLast,
 				m.configureRuntimePodSpecImagePullSecrets,
+				m.addRuntimeClassToDeployment,
 			); tErr != nil {
 				return tErr
 			}
@@ -311,5 +313,13 @@ func (m *Deployment) setConfigMap() error {
 	}
 
 	m.AnnotationConfigMap = annotationConfigMap
+	return nil
+}
+
+// Add runtimeClassName to the deployment spec
+func (m *Deployment) addRuntimeClassToDeployment(deployment *appsv1.Deployment) error {
+	if m.RuntimeClassName != "" {
+		deployment.Spec.Template.Spec.RuntimeClassName = &m.RuntimeClassName
+	}
 	return nil
 }

--- a/controllers/servingruntime_controller.go
+++ b/controllers/servingruntime_controller.go
@@ -259,6 +259,7 @@ func (r *ServingRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		AnnotationsMap:      cfg.RuntimePodAnnotations,
 		LabelsMap:           cfg.RuntimePodLabels,
 		ImagePullSecrets:    cfg.ImagePullSecrets,
+		RuntimeClassName:    cfg.RuntimeClassName,
 	}
 	// if the runtime is disabled, delete the deployment
 	if spec.IsDisabled() || !spec.IsMultiModelRuntime() || !mmEnabled {

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -54,6 +54,7 @@ The following parameters are currently supported. _Note_ the keys are expressed 
 | `runtimePodAnnotations`                    | `metadata.annotations` to be added to all `ServingRuntime` pods                                       | (\*\*\*\*\*) See default annotations below |
 | `imagePullSecrets`                         | The image pull secrets to use for runtime Pods                                                        |                                            |
 | `allowAnyPVC`                              | Allows any PVC in predictor to configure PVC for runtime pods when it's not in storage secret         | `false`                                    |
+| `runtimeClassName`                         | The K8s runtimeClassName to use for the runtime                                                       |
 
 (\*) Currently requires a controller restart to take effect
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -89,6 +89,8 @@ type Config struct {
 
 	ImagePullSecrets []corev1.LocalObjectReference
 
+	RuntimeClassName string
+
 	// For internal use only
 	InternalModelMeshEnvVars EnvVarList
 }


### PR DESCRIPTION
This allows the deployment to use different container runtimes or configuration exposed by K8s runtimeClass.

#### Motivation
Many Kubernetes (K8s) clusters uses different container runtimes for security and isolation reasons. For example in some environment the pods will be executed using [Kata containers ](https://katacontainers.io/) runtime to take advantage of the additional isolation provided by Kata or to leverage [confidential computing ](https://confidentialcontainers.org/) technologies. 
Further, a cluster may have different configurations for the default container runtime. Kubernetes provides [RuntimeClass](https://kubernetes.io/docs/concepts/containers/runtime-class/) to select a different container runtime or configuration. 
ModelMesh currently doesn't provide native capability to execute the serving runtime pods using different container runtimes.  This PR is to add relevant support in ModelMesh for K8s RuntimeClass to enable serving runtime pods to be executed using different container runtimes or configuration for the default container runtime.

#### Modifications
The modifications are in the config and modelmesh deployment transformation to add the runtimeClassName to the deployment spec.

#### Result
The model serving runtime deployments will be using the runtimeClassName configured in the configMap (`model-serving-config-defaults`)
