### PR TITLE
[RHOAIENG-14237] Adding REST_PROXY_SKIP_VERIFY env var.

### DIFF
--- a/controllers/modelmesh/modelmesh.go
+++ b/controllers/modelmesh/modelmesh.go
@@ -37,25 +37,26 @@ const ModelMeshEtcdPrefix = "mm"
 
 // Models a deployment
 type Deployment struct {
-	ServiceName        string
-	ServicePort        uint16
-	Name               string
-	Namespace          string
-	Owner              mf.Owner
-	SRSpec             *kserveapi.ServingRuntimeSpec
-	DefaultVModelOwner string
-	Log                logr.Logger
-	Metrics            bool
-	PrometheusPort     uint16
-	PrometheusScheme   string
-	PayloadProcessors  string
-	ModelMeshImage     string
-	ModelMeshResources *corev1.ResourceRequirements
-	RESTProxyEnabled   bool
-	RESTProxyImage     string
-	RESTProxyResources *corev1.ResourceRequirements
-	RESTProxyPort      uint16
-	PVCs               []string
+	ServiceName         string
+	ServicePort         uint16
+	Name                string
+	Namespace           string
+	Owner               mf.Owner
+	SRSpec              *kserveapi.ServingRuntimeSpec
+	DefaultVModelOwner  string
+	Log                 logr.Logger
+	Metrics             bool
+	PrometheusPort      uint16
+	PrometheusScheme    string
+	PayloadProcessors   string
+	ModelMeshImage      string
+	ModelMeshResources  *corev1.ResourceRequirements
+	RESTProxyEnabled    bool
+	RESTProxySkipVerify bool
+	RESTProxyImage      string
+	RESTProxyResources  *corev1.ResourceRequirements
+	RESTProxyPort       uint16
+	PVCs                []string
 	// internal fields used when templating
 	ModelMeshLimitCPU          string
 	ModelMeshRequestsCPU       string

--- a/controllers/modelmesh/proxy.go
+++ b/controllers/modelmesh/proxy.go
@@ -26,6 +26,7 @@ const (
 	restProxyGrpcMaxMsgSizeEnvVar = "REST_PROXY_GRPC_MAX_MSG_SIZE_BYTES"
 	restProxyGrpcPortEnvVar       = "REST_PROXY_GRPC_PORT"
 	restProxyTlsEnvVar            = "REST_PROXY_USE_TLS"
+	restProxySkipVerifyEnvVar     = "REST_PROXY_SKIP_VERIFY"
 )
 
 func (m *Deployment) addRESTProxyToDeployment(deployment *appsv1.Deployment) error {
@@ -47,6 +48,9 @@ func (m *Deployment) addRESTProxyToDeployment(deployment *appsv1.Deployment) err
 				}, {
 					Name:  restProxyGrpcMaxMsgSizeEnvVar,
 					Value: strconv.Itoa(m.GrpcMaxMessageSize),
+				}, {
+					Name:  restProxySkipVerifyEnvVar,
+					Value: strconv.FormatBool(m.RESTProxySkipVerify),
 				},
 			},
 			Ports: []corev1.ContainerPort{

--- a/controllers/testdata/servingruntime_controller.golden
+++ b/controllers/testdata/servingruntime_controller.golden
@@ -555,6 +555,8 @@ spec:
           value: "false"
         - name: REST_PROXY_GRPC_MAX_MSG_SIZE_BYTES
           value: "16777216"
+        - name: REST_PROXY_SKIP_VERIFY
+          value: "false"
         image: kserve/rest-proxy:latest
         imagePullPolicy: Always
         name: rest-proxy

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -133,10 +133,11 @@ type TLSConfig struct {
 }
 
 type RESTProxyConfig struct {
-	Enabled   bool
-	Port      uint16
-	Image     ImageConfig
-	Resources ResourceRequirements
+	Enabled    bool
+	SkipVerify bool
+	Port       uint16
+	Image      ImageConfig
+	Resources  ResourceRequirements
 }
 
 func (c *Config) GetEtcdSecretName() string {


### PR DESCRIPTION
#### Motivation
rest-proxy has a new environment variable for allowing the user to skip verification when using TLS

#### Modifications
Adding the variable to the RESTProxyConfig and to the Deployments

#### Result
Users will be able to specify if they want to skip verification when using TLS

See: [RHOAIENG-14237](https://issues.redhat.com/browse/RHOAIENG-14237)